### PR TITLE
fix: improve session cleanup and iframe loading

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -54,4 +54,5 @@ interface InvokeMessage {
 
 interface Function {
     ['$mode']: 'Electron' | 'CDP';
+    ['$id']: string;
 }


### PR DESCRIPTION
- Add private #cleanup() method for proper exposeFunction cleanup
- Fix iframe loading by moving Runtime.runIfWaitingForDebugger to finally block
- Call cleanup when sessions are detached to prevent memory leaks
- Add debugging logs for exposeFunction session tracking
- Store sessionId and id as properties on exposed functions
- Fix missing semicolon in service worker error handling