### PR TITLE
Support script options in evaluation flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ const data = await session.evaluate((userData: { name: string; createdAt: Date }
     processedAt: new Date()
   };
 }, { name: 'John', createdAt: new Date() });
+
+// With script-generation options
+const value = await session.evaluate({
+  script: {
+    initScript: 'globalThis.__evaluateStarted = true;',
+    timeout: 3000
+  }
+}, () => {
+  return globalThis.__evaluateStarted;
+});
 ```
 
 ### Execution Contexts
@@ -202,8 +212,8 @@ session.on('execution-context-created', (context) => {
 });
 
 // Listen to session lifecycle events
-session.on('session-attached', (newSession, url) => {
-  console.log('New session attached:', newSession.id, url);
+session.on('session-attached', (newSession) => {
+  console.log('New session attached:', newSession.id);
 });
 
 session.on('session-detached', (detachedSession, reason) => {
@@ -231,7 +241,10 @@ await session.exposeFunction('complexOperation', async (data: any) => {
 }, {
   mode: 'CDP',
   withReturnValue: true,
-  retry: { count: 3, delay: 1000 }
+  retry: { count: 3, delay: 1000 },
+  script: {
+    initScript: 'globalThis.__bridgeReady = true;'
+  }
 });
 ```
 
@@ -244,23 +257,27 @@ The `MainSession.setup()` method provides comprehensive configuration:
 ```ts
 const session = attach(window.webContents, '1.3');
 await session.setup({
-  // SuperJSON configuration
-  preloadSuperJSON: true, // or a custom function
+  // Preload SuperJSON into browser contexts. Use true for the default instance,
+  // or provide a function to customize it before injection.
   preloadSuperJSON: (superJSON) => {
-    // Customize SuperJSON instance
     superJSON.registerCustom({
       isApplicable: (v) => v instanceof MyClass,
       serialize: (v) => v.toJSON(),
       deserialize: (v) => MyClass.fromJSON(v)
     });
   },
+
+  // Default script-generation options for patched WebFrameMain.evaluate calls.
+  // Per-call options can still override these values.
+  initScript: 'globalThis.__cdpSetup = true;',
+  timeout: 3000,
   
   // Execution context tracking
   trackExecutionContexts: true,
   
-  // Auto target attachment
-  autoAttachToRelatedTargets: true, // all targets
-  autoAttachToRelatedTargets: ['iframe', 'worker', 'service_worker'], // specific types
+  // Auto target attachment. Use true for all related targets,
+  // or pass specific target types.
+  autoAttachToRelatedTargets: ['iframe', 'worker', 'service_worker'],
 });
 ```
 
@@ -275,9 +292,8 @@ await session.setup({
 });
 
 // Listen for service worker events
-session.on('service-worker-running-status-changed', (event, session) => {
-  console.log('Service worker status:', event.runningStatus);
-  console.log('Version ID:', event.versionId);
+session.on('service-worker-restarted', (session) => {
+  console.log('Service worker restarted:', session.id);
 });
 
 session.on('service-worker-version-updated', (version, session) => {
@@ -327,6 +343,19 @@ const frame = webFrameMain.fromId(processId, routingId);
 const result = await frame.evaluate(() => {
   return document.title;
 });
+
+// Pass a user gesture, preserving the existing boolean-first form
+await frame.evaluate(true, () => {
+  return document.documentElement.requestFullscreen();
+});
+
+// Or pass per-call options
+const frameState = await frame.evaluate({
+  userGesture: true,
+  initScript: 'globalThis.__frameEvaluate = true;'
+}, () => {
+  return globalThis.__frameEvaluate;
+});
 ```
 
 ### Error Handling
@@ -367,6 +396,9 @@ For detailed API documentation, see [API.md](docs/API.md).
 - `fromSessionId()` - Create session from session ID
 
 #### Key Types
+- `EvaluateOptions` - CDP evaluate options plus nested script-generation options
+- `GenerateScriptOptions` - Script wrapper options such as `initScript` and `timeout`
+- `WebFrameEvaluateOptions` - Options accepted by `WebFrameMain.evaluate`
 - `SessionWithId` - Session with guaranteed ID
 - `DetachedSession` - Detached session with limited functionality
 - `DetachedSessionWithId` - Detached session with guaranteed ID
@@ -404,13 +436,13 @@ await session.setup({
 });
 
 // Listen for new sessions
-session.on('session-attached', (newSession, url) => {
-  console.log('New target attached:', newSession.target.type, url);
+session.on('session-attached', (newSession) => {
+  console.log('New target attached:', newSession.target.type);
 });
 
 // Listen for service worker events
-session.on('service-worker-running-status-changed', (event, session) => {
-  console.log('Service worker status changed:', event.runningStatus);
+session.on('service-worker-restarted', (session) => {
+  console.log('Service worker restarted:', session.id);
 });
 ```
 
@@ -432,8 +464,8 @@ session.on('execution-context-created', (context) => {
   console.log('New context created:', context.id);
 });
 
-session.on('execution-context-destroyed', (contextId) => {
-  console.log('Context destroyed:', contextId);
+session.on('execution-context-destroyed', (event) => {
+  console.log('Context destroyed:', event.executionContextId);
 });
 
 session.on('execution-contexts-cleared', () => {
@@ -454,7 +486,7 @@ await session.setup({
 
 // Navigate to page
 await session.send('Page.navigate', { url: 'https://example.com' });
-await session.send('Page.loadEventFired');
+await new Promise(resolve => session.once('Page.loadEventFired', resolve));
 
 // Extract data with complex types
 const data = await session.evaluate(() => {
@@ -525,8 +557,8 @@ session.on('Performance.metrics', (params) => {
 });
 
 // Monitor service worker performance
-session.on('service-worker-running-status-changed', (event, session) => {
-  console.log('Service worker status:', event.runningStatus);
+session.on('service-worker-restarted', (session) => {
+  console.log('Service worker restarted:', session.id);
 });
 
 // Get memory usage with complex data
@@ -557,15 +589,15 @@ if (!webContents.debugger.isAttached()) {
 **2. Function Execution Timeout**
 ```ts
 // Increase timeout for long-running functions
-const result = await session.evaluate(() => {
+const result = await session.evaluate({ timeout: 30000 }, () => {
   // Long-running operation
-}, { timeout: 30000 }); // 30 seconds
+}); // 30 seconds
 ```
 
 **3. Serialization Issues**
 ```ts
-// Use SuperJSON for complex data types
-await session.enableSuperJSON();
+// Preload SuperJSON for complex data types
+await session.enableSuperJSONPreload();
 const result = await session.evaluate((data) => {
   return new Map(Object.entries(data));
 }, { key: 'value' });
@@ -573,9 +605,9 @@ const result = await session.evaluate((data) => {
 
 ## Requirements
 
-- Node.js 14+
-- Electron 13+
-- TypeScript 4.5+ (for TypeScript projects)
+- Node.js 22.12+ for the current Electron 42 development/test setup
+- Electron 42+
+- TypeScript 5.4+ for TypeScript projects
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,8 +36,10 @@ Configures the session with comprehensive options.
 
 **Options:**
 - `preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void)` - SuperJSON configuration
+- `initScript?: (() => void) | string` - Script body to run before each generated `WebFrameMain.evaluate` wrapper
+- `timeout?: number` - Maximum wait time, in milliseconds, for a preloaded SuperJSON instance
 - `trackExecutionContexts?: boolean` - Enable execution context tracking
-- `autoAttachToRelatedTargets?: boolean | TargetType[]` - Auto attachment configuration
+- `autoAttachToRelatedTargets?: boolean | Target['type'][]` - Auto attachment configuration
 
 **Behavior:**
 - Sets up WebFrameMain integration
@@ -51,6 +53,8 @@ Configures the session with comprehensive options.
 const session = new MainSession(window.webContents, undefined, '1.3');
 await session.setup({
   preloadSuperJSON: true,
+  initScript: 'globalThis.__cdpSetup = true;',
+  timeout: 3000,
   trackExecutionContexts: true,
   autoAttachToRelatedTargets: ['iframe', 'worker', 'service_worker']
 });
@@ -59,6 +63,27 @@ await session.setup({
 ### Properties
 
 Inherits all properties from the base `Session` class.
+
+### Patched `WebFrameMain.evaluate`
+
+`MainSession.setup()` patches Electron frames with a typed `evaluate` helper. The helper accepts the existing boolean-first user-gesture form and a new object-options form.
+
+```ts
+// Existing boolean-first form
+await webContents.mainFrame.evaluate(true, () => {
+  return document.documentElement.requestFullscreen();
+});
+
+// Options-object form
+const ready = await webContents.mainFrame.evaluate({
+  userGesture: true,
+  initScript: 'globalThis.__frameReady = true;'
+}, () => {
+  return globalThis.__frameReady;
+});
+```
+
+The options-object form accepts `userGesture`, top-level script-generation options such as `initScript` and `timeout`, and the nested `{ script }` shape used by `Session.evaluate`.
 
 ## Session Class
 
@@ -92,9 +117,13 @@ Sends a command to the browser's DevTools protocol with full type safety.
 
 **Examples:**
 ```ts
-// Page commands
+// Page and Runtime commands
 await session.send('Page.enable');
-const title = await session.send('Page.getTitle');
+const titleResponse = await session.send('Runtime.evaluate', {
+  expression: 'document.title',
+  returnByValue: true
+});
+const title = titleResponse.result.value;
 
 // Runtime commands with parameters
 const result = await session.send('Runtime.evaluate', {
@@ -109,7 +138,12 @@ const response: Protocol.Runtime.EvaluateResponse = await session.send('Runtime.
 });
 ```
 
-#### `evaluate<T, A extends unknown[]>(fn: (...args: A) => T, ...args: A): Promise<T>`
+#### `evaluate`
+
+```ts
+evaluate<T, A extends unknown[]>(fn: (...args: A) => T, ...args: A): Promise<T>;
+evaluate<T, A extends unknown[]>(options: EvaluateOptions, fn: (...args: A) => T, ...args: A): Promise<T>;
+```
 
 Executes a function in the browser context with full type safety and SuperJSON serialization.
 
@@ -118,6 +152,7 @@ Executes a function in the browser context with full type safety and SuperJSON s
 - `A` - The argument types of the function
 
 **Parameters:**
+- `options` - CDP `Runtime.evaluate` options plus nested script-generation options, when using the options overload
 - `fn` - The function to execute in the browser context
 - `...args` - Arguments to pass to the function (automatically serialized with SuperJSON)
 
@@ -147,9 +182,19 @@ const result = await session.evaluate((userData: { name: string; createdAt: Date
     processedAt: new Date()
   };
 }, { name: 'John', createdAt: new Date() });
+
+// Script-generation options for this call only
+const flag = await session.evaluate({
+  script: {
+    initScript: 'globalThis.__beforeEvaluate = true;',
+    timeout: 3000
+  }
+}, () => {
+  return globalThis.__beforeEvaluate;
+});
 ```
 
-#### `exposeFunction<T, A extends unknown[]>(name: string, fn: (...args: A) => Promise<T> | T, options?: ExposeFunctionOptions): Promise<void>`
+#### `exposeFunction<T, A extends unknown[]>(name: string, fn: (...args: A) => Promise<T> | T, options?: ExposeFunctionOptions): Promise<boolean>`
 
 Exposes a Node.js function to the browser's global context with advanced options.
 
@@ -162,10 +207,14 @@ Exposes a Node.js function to the browser's global context with advanced options
 - `fn` - The function to expose (can be async or sync)
 - `options` - Optional settings for exposing the function
 
+**Returns:** Promise that resolves to `true` when the function is exposed, or `false` when it is already exposed and `overwrite` is not enabled.
+
 **Options:**
 - `mode?: 'Electron' | 'CDP'` - Detection method (default: 'Electron')
 - `withReturnValue?: boolean | WithReturnValueOptions` - Whether to await return values
 - `retry?: boolean | RetryOptions` - Retry configuration for failed calls
+- `overwrite?: boolean` - Replace an existing exposed function with the same name
+- `script?: Omit<GenerateScriptOptions, 'session'>` - Script-generation options used while installing or updating the browser-side bridge
 
 **Throws:**
 - `Error` - If function exposure fails
@@ -188,7 +237,10 @@ await session.exposeFunction('complexOperation', async (data: any) => {
 }, {
   mode: 'CDP',
   withReturnValue: true,
-  retry: { count: 3, delay: 1000 }
+  retry: { count: 3, delay: 1000 },
+  script: {
+    initScript: 'globalThis.__nativeBridgeInstall = true;'
+  }
 });
 
 // Nested function exposure
@@ -265,7 +317,7 @@ Enables automatic attachment to related targets like iframes, workers, and other
 - `options` - Optional settings for auto attachment
 
 **Options:**
-- `targetTypes?: TargetType[]` - Specific target types to attach to
+- `targetTypes?: Target['type'][]` - Specific target types to attach to
 - `recursive?: boolean` - Whether to recursively attach to targets created by attached targets
 
 **Returns:** Promise that resolves to `true` if enabled, `false` if already enabled
@@ -386,11 +438,17 @@ constructor(session: Session, idOrDescription?: Protocol.Runtime.ExecutionContex
 
 ### Methods
 
-#### `evaluate<T, A extends unknown[]>(fn: (...args: A) => T, ...args: A): Promise<T>`
+#### `evaluate`
+
+```ts
+evaluate<T, A extends unknown[]>(fn: (...args: A) => T, ...args: A): Promise<T>;
+evaluate<T, A extends unknown[]>(options: EvaluateOptions, fn: (...args: A) => T, ...args: A): Promise<T>;
+```
 
 Executes a function in the specific execution context.
 
 **Parameters:**
+- `options` - CDP `Runtime.evaluate` options plus nested script-generation options, when using the options overload
 - `fn` - The function to execute
 - `...args` - Arguments to pass to the function
 
@@ -401,6 +459,14 @@ Executes a function in the specific execution context.
 const context = session.executionContexts.get(contextId);
 const result = await context.evaluate(() => {
   return window.location.href;
+});
+
+const seeded = await context.evaluate({
+  script: {
+    initScript: 'globalThis.__contextSeed = 1;'
+  }
+}, () => {
+  return globalThis.__contextSeed;
 });
 ```
 
@@ -477,7 +543,82 @@ if (isAttached(window.webContents)) {
 }
 ```
 
+### `patchWebFrameMain`
+
+```ts
+patchWebFrameMain(session: Session, frame: WebFrameMain, options?: WebFramePatchOptions): WebFrameMain
+```
+
+Installs the typed `evaluate` helper on an Electron `WebFrameMain`.
+
+`MainSession.setup()` applies this automatically to existing and newly created frames, so most applications do not need to call it directly.
+
+**Parameters:**
+- `session` - Session used for SuperJSON serialization and script generation
+- `frame` - Electron frame to patch
+- `options` - Default script-generation options for the patched frame
+
+**Examples:**
+```ts
+const frame = patchWebFrameMain(session, webContents.mainFrame, {
+  initScript: 'globalThis.__patchedFrame = true;'
+});
+
+const result = await frame.evaluate({
+  userGesture: true
+}, () => {
+  return globalThis.__patchedFrame;
+});
+```
+
 ## Type Definitions
+
+### `GenerateScriptOptions`
+
+Options used while building the browser-side wrapper script for evaluate calls.
+
+```ts
+type GenerateScriptOptions = {
+  session?: Session;
+  timeout?: number;
+  initScript?: (() => void) | string;
+};
+```
+
+**Properties:**
+- `session` - Internal session used for SuperJSON customization and serialization
+- `timeout` - Maximum wait time, in milliseconds, for a preloaded SuperJSON instance
+- `initScript` - Script body or function body to run before the generated evaluate wrapper setup
+
+### `WebFrameEvaluateOptions`
+
+Options accepted by `WebFrameMain.evaluate` when its first argument is an object.
+
+```ts
+type WebFrameEvaluateOptions = Omit<GenerateScriptOptions, 'session'> & {
+  userGesture?: boolean;
+  script?: Omit<GenerateScriptOptions, 'session'>;
+};
+```
+
+Use top-level `initScript` and `timeout` for direct frame calls. The nested `script` form is also accepted so internal call sites can reuse the same shape as `Session.evaluate`.
+
+```ts
+await frame.evaluate({
+  userGesture: true,
+  initScript: 'globalThis.__frameReady = true;'
+}, () => globalThis.__frameReady);
+```
+
+### `WebFramePatchOptions`
+
+Default options installed by `patchWebFrameMain` for patched frame evaluate calls.
+
+```ts
+type WebFramePatchOptions = Omit<GenerateScriptOptions, 'session'> & {
+  overwrite?: boolean;
+};
+```
 
 ### `SessionWithId`
 
@@ -530,8 +671,10 @@ Options for setting up a MainSession.
 ```ts
 interface MainSessionSetupOptions {
   preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void);
+  initScript?: (() => void) | string;
+  timeout?: number;
   trackExecutionContexts?: boolean;
-  autoAttachToRelatedTargets?: boolean | TargetType[];
+  autoAttachToRelatedTargets?: boolean | Target['type'][];
 }
 ```
 
@@ -543,8 +686,7 @@ Options for creating a Session.
 interface SessionOptions {
   protocolVersion?: string;
   trackExecutionContexts?: boolean;
-  autoAttachToRelatedTargets?: boolean | TargetType[];
-  preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void);
+  autoAttachToRelatedTargets?: boolean | Target['type'][];
 }
 ```
 
@@ -554,7 +696,7 @@ Options for setting auto attach.
 
 ```ts
 interface SetAutoAttachOptions {
-  targetTypes?: TargetType[];
+  targetTypes?: Target['type'][];
   recursive?: boolean;
 }
 ```
@@ -568,6 +710,8 @@ interface ExposeFunctionOptions {
   mode?: 'Electron' | 'CDP';
   withReturnValue?: boolean | WithReturnValueOptions;
   retry?: boolean | RetryOptions;
+  overwrite?: boolean;
+  script?: Omit<GenerateScriptOptions, 'session'>;
 }
 ```
 
@@ -587,7 +731,9 @@ type EvaluateOptions = Omit<Protocol.Runtime.EvaluateRequest,
   | 'generatePreview' 
   | 'serializationOptions' 
   | 'objectGroup'
->;
+> & {
+  script?: Omit<GenerateScriptOptions, 'session'>;
+};
 ```
 
 **Available Options:**
@@ -595,9 +741,9 @@ type EvaluateOptions = Omit<Protocol.Runtime.EvaluateRequest,
 - `silent?: boolean` - Whether to suppress console output
 - `includeCommandLineAPI?: boolean` - Whether to include command line API
 - `userGesture?: boolean` - Whether to treat as user gesture
-- `awaitPromise?: boolean` - Whether to await promises (always true)
-- `returnByValue?: boolean` - Whether to return by value (always false)
-- `generatePreview?: boolean` - Whether to generate preview (always false)
+- `script?: Omit<GenerateScriptOptions, 'session'>` - Script-generation options for this evaluate call
+
+`EvaluateOptions.timeout` is forwarded to CDP `Runtime.evaluate`. `EvaluateOptions.script.timeout` controls how long the generated wrapper waits for a preloaded SuperJSON instance.
 
 ### `WithReturnValueOptions`
 
@@ -668,8 +814,8 @@ session.on('Page.loadEventFired', () => {
 Emitted when a new session is attached.
 
 ```ts
-session.on('session-attached', (newSession: SessionWithId, url: string) => {
-  console.log('New session attached:', newSession.id, url);
+session.on('session-attached', (newSession: SessionWithId, initializationTasks: Promise<unknown>[]) => {
+  console.log('New session attached:', newSession.id, initializationTasks.length);
 });
 ```
 
@@ -713,14 +859,13 @@ session.on('execution-contexts-cleared', () => {
 });
 ```
 
-#### `service-worker-running-status-changed`
+#### `service-worker-restarted`
 
-Emitted when a service worker's running status changes.
+Emitted when an attached service worker restarts after it was stopped.
 
 ```ts
-session.on('service-worker-running-status-changed', (event: { runningStatus: string; versionId: number }, session: SessionWithId) => {
-  console.log('Service worker status changed:', event.runningStatus);
-  console.log('Version ID:', event.versionId);
+session.on('service-worker-restarted', (session: SessionWithId) => {
+  console.log('Service worker restarted:', session.id);
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "electron-cdp-utils",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-cdp-utils",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "ISC",
       "dependencies": {
         "buffer": "^6.0.3",
-        "devtools-protocol": "^0.0.1624250",
+        "devtools-protocol": "^0.0.1629771",
         "events": "^3.3.0",
         "superjson": "2.2.6"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.28.5",
         "concurrently": "^9.2.1",
-        "electron": "^41.5.0",
+        "electron": "^42.0.1",
         "esbuild": "^0.28.0",
         "eslint": "^10.3.0",
-        "oxlint": "^1.62.0",
+        "oxlint": "^1.64.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.2"
+        "typescript-eslint": "^8.59.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -478,25 +478,37 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1154,9 +1166,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.62.0.tgz",
-      "integrity": "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.64.0.tgz",
+      "integrity": "sha512-2r6Nq3XXGLHEXKkSj8JtmJ6N4gDw431DPFOg0ZoJHlNjnG6HVMm/ksQ10m0HJ8WBvwgMe1L50UHPaYZutCRPCw==",
       "cpu": [
         "arm"
       ],
@@ -1171,9 +1183,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.62.0.tgz",
-      "integrity": "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.64.0.tgz",
+      "integrity": "sha512-ePJMpePgg7fBv+L/hVx1xXRU5/5gd5m0obLA6hPEfLXF3GjpR8idIDbY1dhQYhyz1ms2wdTccSboo6KEd2Oxtg==",
       "cpu": [
         "arm64"
       ],
@@ -1188,9 +1200,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.62.0.tgz",
-      "integrity": "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.64.0.tgz",
+      "integrity": "sha512-U4DMLQd10gJLuoSTLSGbfv3bGjTlUNsScm9Dgb8wwBqmCzidf1pE1pXV4doGNxqwH3KtVng1AGTINA0NvkGLvQ==",
       "cpu": [
         "arm64"
       ],
@@ -1205,9 +1217,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.62.0.tgz",
-      "integrity": "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.64.0.tgz",
+      "integrity": "sha512-GoRIL48QWm4/TAvjN8pB1nAG+1/uqc9EdnWT9zqHeb6wsmjZtywj8VRe5aGW47Fdb64YtLOsdLqVxOvQuz98Wg==",
       "cpu": [
         "x64"
       ],
@@ -1222,9 +1234,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.62.0.tgz",
-      "integrity": "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.64.0.tgz",
+      "integrity": "sha512-5dFkv4tkg7PxJJGS9/OjrJwjhuHczrd3OQOkRE0wHcLM+ncUnULtzEPWjqGOxTXxZnLWcB91bGiIznx89TVXyQ==",
       "cpu": [
         "x64"
       ],
@@ -1239,9 +1251,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.62.0.tgz",
-      "integrity": "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.64.0.tgz",
+      "integrity": "sha512-jsBqMLl/uOL5+Kq/+BtK9FrmiNGUbx8SiyZXv+WlUxA45KuwcLu9BfiSIL3I3DBDgWM3yZizDITnTK9BcqNBQg==",
       "cpu": [
         "arm"
       ],
@@ -1256,9 +1268,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.62.0.tgz",
-      "integrity": "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.64.0.tgz",
+      "integrity": "sha512-1lrj8At/Uuc9GhjrVFBQo0NEjfBrTkzpmtHIGAhNnIXqn1CAyGL+qrztUsXb2GIluJrpl9Q7qRLJOb/NqydacQ==",
       "cpu": [
         "arm"
       ],
@@ -1273,13 +1285,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.62.0.tgz",
-      "integrity": "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.64.0.tgz",
+      "integrity": "sha512-HpSQbubwh03mMhAdy2BYtad/fsY8vDFHDAb6bUwuCYg2VD3xCQgn6ArKcO0oZyLCheacKTv4PrF3Mfu5hgoE2g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,13 +1305,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.62.0.tgz",
-      "integrity": "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.64.0.tgz",
+      "integrity": "sha512-00QQ0h0Y7u0G69BgiH3+ky2aaq/QvkDL6DYok8htIuJHxybiux5aQ8jwmg8qIk9wha6UagUP2BAwAzbemcJbpg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,13 +1325,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.62.0.tgz",
-      "integrity": "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.64.0.tgz",
+      "integrity": "sha512-2GaimTV6EMW+s5HS0An3oGbQme3BgHswvfVdGk3EB57Xe9+/gyT+Qd7lNVzb3rtir52vbIPzXfaYArzs5b5zcw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,13 +1345,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.62.0.tgz",
-      "integrity": "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.64.0.tgz",
+      "integrity": "sha512-H46AtFb9wypjoVwGdlxrm0DsD809NGmtiK9HiyPKTxkSte2YjhC4S+00rOIrwCaxcyPiGid3Y3OMXp5KMAkGZw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,13 +1365,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.62.0.tgz",
-      "integrity": "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.64.0.tgz",
+      "integrity": "sha512-HEgsidjjvvyzdg82icYkuFCf7REDV7B9JFwbIMbVwrKLBY0MrXX+bku3POn/hduZ2yW91IyVDUMq0Bf02KwXQw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,13 +1385,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.62.0.tgz",
-      "integrity": "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.64.0.tgz",
+      "integrity": "sha512-Axvm8qryotmKN00P5w4JapaSjvP2LOSbdbBJiX+2SuHd3QzhW7TUc8skqgw+ahQZ5DmzEYeHCqauvW8f32Ns6Q==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,13 +1405,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.62.0.tgz",
-      "integrity": "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.64.0.tgz",
+      "integrity": "sha512-cR60vSd7+m+KRZ3GQGfDxWwahW5RMXg0qlGvAluZr0fTUYvw0H9N9AXAF/M/PMqgytyqvVNmBAkJG9l7U30Y1g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,13 +1425,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.62.0.tgz",
-      "integrity": "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.64.0.tgz",
+      "integrity": "sha512-2u/aPZ9pEg7HnvZPDsHxUGNnrpr4qaHi+mCgLgpt+LYRzPrS4Px4wPfkIdRdr2GvKnaYyt+XSlto0Vm5sbStTg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,9 +1445,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.62.0.tgz",
-      "integrity": "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.64.0.tgz",
+      "integrity": "sha512-kfhkGfCdoXLSxEkrhDlJrvBYajGmq+ma4EMc53dsOWTq+rIBOlI0vTBmpZNnM5oH2LY/K/w1HAK+UQEgjgpVUg==",
       "cpu": [
         "arm64"
       ],
@@ -1426,9 +1462,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.62.0.tgz",
-      "integrity": "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.64.0.tgz",
+      "integrity": "sha512-r/cNKBFieONoVu2bb1KkVouq9W+edDUgHumXJGphCRRj+U0xaD4nanrw8ZOqo0IsutPkEM4vCcGBpak6x5aXMg==",
       "cpu": [
         "arm64"
       ],
@@ -1443,9 +1479,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz",
-      "integrity": "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.64.0.tgz",
+      "integrity": "sha512-tUw0xUUwEFVZbpJoeCblkv8SJA4Xz3CdXCJbAnBsiNLyxDrk2tLcxEAS6M73Q7hHHDg3OtwI8vZVK3t5RJt4Gw==",
       "cpu": [
         "ia32"
       ],
@@ -1460,9 +1496,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz",
-      "integrity": "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.64.0.tgz",
+      "integrity": "sha512-9CBR+LO0JVST87fNTzzNxS5I29jIUO5gxT9i9+M3SDHHALElj9sY1Prf12tad3vIRC6OD7Ehtvvh+sn13vSwHw==",
       "cpu": [
         "x64"
       ],
@@ -1474,45 +1510,6 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/esrecurse": {
@@ -1529,29 +1526,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "24.12.2",
@@ -1561,16 +1541,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/yauzl": {
@@ -1585,17 +1555,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1608,7 +1578,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1624,16 +1594,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1649,14 +1619,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1671,14 +1641,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1689,9 +1659,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1706,15 +1676,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1731,9 +1701,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1745,16 +1715,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1773,9 +1743,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1786,16 +1756,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1810,13 +1780,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1923,15 +1893,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2013,35 +1974,6 @@
         "node": "*"
       }
     },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001735",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
@@ -2107,19 +2039,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -2223,35 +2142,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2259,85 +2149,29 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1624250",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
-      "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
+      "version": "0.0.1629771",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1629771.tgz",
+      "integrity": "sha512-QN8rTUYP0X//42UNHxj8yVU262qtoM27SX0WlE5qaLf/6Y4+RsL8HAn2MUeQ4rVgGF/oRfpi8U0958DsSS5g6w==",
       "license": "BSD-3-Clause"
     },
     "node_modules/electron": {
-      "version": "41.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz",
-      "integrity": "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==",
+      "version": "42.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.1.tgz",
+      "integrity": "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
+        "@electron/get": "^5.0.0",
         "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2366,44 +2200,17 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -2752,21 +2559,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2817,97 +2609,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2923,41 +2624,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/ieee754": {
@@ -3093,14 +2759,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3113,16 +2771,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -3165,16 +2813,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3184,30 +2822,6 @@
       "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3248,30 +2862,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3301,9 +2891,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.62.0.tgz",
-      "integrity": "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.64.0.tgz",
+      "integrity": "sha512-Star3SNpWPeWFPw7kRXIhXUSn6fdiAl25q15CQzH/9WaOtG6e9CWTc25vNZOCr4PE1yEP1GtKJKIKglhj3OmEQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3316,43 +2906,33 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.62.0",
-        "@oxlint/binding-android-arm64": "1.62.0",
-        "@oxlint/binding-darwin-arm64": "1.62.0",
-        "@oxlint/binding-darwin-x64": "1.62.0",
-        "@oxlint/binding-freebsd-x64": "1.62.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.62.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.62.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.62.0",
-        "@oxlint/binding-linux-arm64-musl": "1.62.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.62.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.62.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.62.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.62.0",
-        "@oxlint/binding-linux-x64-gnu": "1.62.0",
-        "@oxlint/binding-linux-x64-musl": "1.62.0",
-        "@oxlint/binding-openharmony-arm64": "1.62.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.62.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.62.0",
-        "@oxlint/binding-win32-x64-msvc": "1.62.0"
+        "@oxlint/binding-android-arm-eabi": "1.64.0",
+        "@oxlint/binding-android-arm64": "1.64.0",
+        "@oxlint/binding-darwin-arm64": "1.64.0",
+        "@oxlint/binding-darwin-x64": "1.64.0",
+        "@oxlint/binding-freebsd-x64": "1.64.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.64.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.64.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.64.0",
+        "@oxlint/binding-linux-arm64-musl": "1.64.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.64.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.64.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.64.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.64.0",
+        "@oxlint/binding-linux-x64-gnu": "1.64.0",
+        "@oxlint/binding-linux-x64-musl": "1.64.0",
+        "@oxlint/binding-openharmony-arm64": "1.64.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.64.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.64.0",
+        "@oxlint/binding-win32-x64-msvc": "1.64.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.18.0"
+        "oxlint-tsgolint": ">=0.22.1"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
           "optional": true
         }
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -3475,19 +3055,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3496,45 +3063,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/rxjs": {
@@ -3555,31 +3083,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/shebang-command": {
@@ -3617,14 +3120,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3755,20 +3250,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -3784,16 +3265,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3807,22 +3288,23 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-cdp-utils",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "author": "ntoskrnl7@gmail.com",
   "license": "ISC",
   "main": "index.js",
@@ -9,26 +9,26 @@
     "lint": "concurrently npm:lint:es npm:lint:ox",
     "lint:es": "eslint src/*.ts",
     "lint:ox": "oxlint src",
-    "test": "npm run test:mock",
+    "test": "npm run build && npm run test:mock && npm run test:e2e",
     "test:mock": "node --test test/mock/*.test.cjs",
     "test:e2e": "node --test test/e2e/*.test.cjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "devtools-protocol": "^0.0.1624250",
+    "devtools-protocol": "^0.0.1629771",
     "events": "^3.3.0",
     "superjson": "2.2.6"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.28.5",
     "concurrently": "^9.2.1",
-    "electron": "^41.5.0",
+    "electron": "^42.0.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.3.0",
-    "oxlint": "^1.62.0",
+    "oxlint": "^1.64.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.2"
+    "typescript-eslint": "^8.59.3"
   },
   "sideEffects": [
     "SuperJSON.browser.js"

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -4,7 +4,7 @@ import type Protocol from 'devtools-protocol';
 
 import { WebContents, webFrameMain, WebFrameMain } from 'electron';
 import { Session as CDPSession, SessionOptions } from './session';
-import { generateScriptString } from './utils';
+import { type GenerateScriptOptions, type WebFrameEvaluateOptions, type WebFramePatchOptions, patchWebFrameMain } from './utils';
 import SuperJSON from 'superjson';
 
 declare global {
@@ -33,6 +33,14 @@ declare global {
             evaluate<A extends unknown[], R>(userGesture: boolean, fn: (...args: A) => R, ...args: A): Promise<R>;
 
             /**
+             * A promise that resolves with the result of the executed code or is rejected if
+             * execution throws or results in a rejected promise.
+             *
+             * Evaluates `fn(...args)` in page with per-call frame evaluation options.
+             */
+            evaluate<A extends unknown[], R>(options: WebFrameEvaluateOptions, fn: (...args: A) => R, ...args: A): Promise<R>;
+
+            /**
               * A promise that resolves with the result of the executed code or is rejected if
               * execution throws or results in a rejected promise.
               *
@@ -49,17 +57,23 @@ export class MainSession extends CDPSession {
     }
 
     /**
-     * Sets up the session.
-     * 
+     * Sets up the main Electron session.
+     *
+     * The setup process applies session options, optionally preloads SuperJSON,
+     * patches `WebFrameMain.evaluate` on existing and newly created frames, and
+     * injects the frame-id helper used by exposed functions.
+     *
      * @param options - Configuration options object.
      * @param options.preloadSuperJSON - If true, SuperJSON will be loaded into all contexts upfront.
      *                                   If false, SuperJSON will only be loaded during evaluate calls.
-     *                                   This can also be a callback function to customize the SuperJSON instance.  
+     *                                   This can also be a callback function to customize the SuperJSON instance.
+     * @param options.timeout - Maximum wait time, in milliseconds, for patched frame evaluate calls to find a preloaded SuperJSON instance.
+     * @param options.initScript - Script body or function body to run at the beginning of each patched `WebFrameMain.evaluate` call.
      * @param options.trackExecutionContexts - Whether to track Runtime execution context and maintain a map of them in the `executionContexts` property.
      * @param options.autoAttachToRelatedTargets - Whether to automatically attach to related targets.
-     * @returns A promise that resolves when the session is setup.
+     * @returns A promise that resolves when the session is set up.
      */
-    async setup(options?: { preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void) } & SessionOptions) {
+    async setup(options?: { preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void) } & Omit<GenerateScriptOptions, 'session'> & SessionOptions) {
 
         const promises = [];
         promises.push(this.applyOptions(options));
@@ -69,29 +83,8 @@ export class MainSession extends CDPSession {
             promises.push(this.enableSuperJSONPreload(typeof preloadSuperJSON === 'boolean' ? undefined : preloadSuperJSON));
         }
 
-        const initializeFrame = async (session: CDPSession, frame: WebFrameMain | undefined | null) => {
+        const applyFrameId = async (frame: WebFrameMain | undefined | null) => {
             if (frame && !frame.isDestroyed()) {
-                frame.evaluate = async function <A0, A extends unknown[], R>(this: WebFrameMain, userGestureOrFn: boolean | ((...args: [A0, ...A]) => R), fnOrArg0: A0 | ((...args: [A0, ...A]) => R), ...args: A): Promise<R> {
-                    try {
-                        if (typeof userGestureOrFn === 'boolean') {
-                            return session.superJSON.parse(await (this.executeJavaScript(generateScriptString({ session }, fnOrArg0 as (...args: A) => R, ...args), userGestureOrFn)) as string);
-                        } else {
-                            return session.superJSON.parse(await (this.executeJavaScript(generateScriptString({ session }, userGestureOrFn, fnOrArg0 as A0, ...args))) as string);
-                        }
-                    } catch (error) {
-                        if (typeof error === 'string') {
-                            let result;
-                            try {
-                                result = session.superJSON.parse(error);
-                            } catch {
-                            }
-                            if (result) {
-                                throw result;
-                            }
-                        }
-                        throw error;
-                    }
-                }
                 await frame.executeJavaScript(`
                     globalThis.$cdp ??= { consoleDebug: console.debug };
                     if (globalThis.$cdp.frameIdResolve) {
@@ -103,25 +96,49 @@ export class MainSession extends CDPSession {
             }
         };
 
+        const frameEvaluateOptions: WebFramePatchOptions = {
+            initScript: options?.initScript,
+            timeout: options?.timeout
+        };
+
+        const patchFrame = (frame: WebFrameMain | undefined | null) => {
+            if (frame && !frame.isDestroyed()) {
+                patchWebFrameMain(this, frame, frameEvaluateOptions);
+            }
+        };
+
         const webContents = this.webContents;
-        initializeFrame(this, webContents.mainFrame);
+        patchFrame(webContents.mainFrame);
+        applyFrameId(webContents.mainFrame);
         if (webContents.getMaxListeners() <= webContents.listenerCount('did-frame-navigate')) {
             webContents.setMaxListeners(webContents.listenerCount('did-frame-navigate') + 1);
         }
         webContents
-            .on('did-frame-navigate', (event, url, httpResponseCode, httpStatusText, isMainFrame, frameProcessId, frameRoutingId) =>
-                initializeFrame(this, webFrameMain.fromId(frameProcessId, frameRoutingId)));
+            .on('frame-created', (event, details) => {
+                patchFrame(details.frame);
+            });
+        webContents
+            .on('did-frame-navigate', (event, url, httpResponseCode, httpStatusText, isMainFrame, frameProcessId, frameRoutingId) => {
+                const frame = webFrameMain.fromId(frameProcessId, frameRoutingId);
+                patchFrame(frame);
+                applyFrameId(frame);
+            });
 
-        promises.push(this.send('Page.addScriptToEvaluateOnNewDocument', {
-            runImmediately: true,
-            source: `
-            globalThis.$cdp ??= { consoleDebug: console.debug };
-            if (globalThis.$cdp.frameId === undefined) {
-                const { promise, resolve } = Promise.withResolvers();
-                globalThis.$cdp.frameId = promise;
-                globalThis.$cdp.frameIdResolve = resolve;
-            }`
-        }));
+        promises.push((async () => {
+            if ((await this.getDomains()).some(domain => domain.name === 'Page')) {
+                await this.send('Page.enable');
+            }
+            await this.send('Page.addScriptToEvaluateOnNewDocument', {
+                runImmediately: true,
+                source: `
+                globalThis.$cdp ??= { consoleDebug: console.debug };
+                if (globalThis.$cdp.frameId === undefined) {
+                    const { promise, resolve } = Promise.withResolvers();
+                    globalThis.$cdp.frameId = promise;
+                    globalThis.$cdp.frameIdResolve = resolve;
+                }`
+            });
+        })());
 
         await Promise.all(promises);
     }

--- a/src/executionContext.ts
+++ b/src/executionContext.ts
@@ -135,15 +135,16 @@ export class ExecutionContext {
     }
 
     async #evaluate<T, A extends unknown[]>(options: EvaluateOptions | undefined, fn: (...args: A) => T, ...args: A): Promise<T> {
+        const { script, ...runtimeOptions } = options ?? {};
         const res = await this.session.send('Runtime.evaluate', {
-            expression: generateScriptString({ ...options, session: this.session }, fn, ...args),
+            expression: generateScriptString({ ...script, session: this.session }, fn, ...args),
             contextId: this.id,
             throwOnSideEffect: false,
             awaitPromise: true,
             replMode: false,
             returnByValue: false,
             generatePreview: false,
-            ...options
+            ...runtimeOptions
         });
 
         if (res.exceptionDetails) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import { Protocol } from 'devtools-protocol/types/protocol.d';
+import { GenerateScriptOptions } from './utils';
 export { Protocol } from 'devtools-protocol/types/protocol.d';
 export { SuperJSON } from 'superjson';
 
-export type EvaluateOptions = Omit<Protocol.Runtime.EvaluateRequest, 'contextId' | 'uniqueContextId' | 'expression' | 'throwOnSideEffect' | 'awaitPromise' | 'replMode' | 'returnByValue' | 'generatePreview' | 'serializationOptions' | 'objectGroup'>;
+/**
+ * Options accepted by `Session.evaluate` and `ExecutionContext.evaluate`.
+ *
+ * Includes the supported CDP `Runtime.evaluate` options plus nested
+ * script-generation options such as `script.initScript` and `script.timeout`.
+ * The session used for script generation is managed internally.
+ */
+export type EvaluateOptions = Omit<Protocol.Runtime.EvaluateRequest, 'contextId' | 'uniqueContextId' | 'expression' | 'throwOnSideEffect' | 'awaitPromise' | 'replMode' | 'returnByValue' | 'generatePreview' | 'serializationOptions' | 'objectGroup'> & { script?: Omit<GenerateScriptOptions, 'session'> };
 
 export * from './electron';
 export * from './session';

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,8 +4,8 @@
 import EventEmitter from 'events'; // NOSONAR: Intentionally using `events` for compatibility with both browser and Node.js runtimes.
 import { Protocol } from 'devtools-protocol/types/protocol.d';
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping.d';
-import Electron, { WebContents, WebFrameMain, webFrameMain } from 'electron';
-import { EvaluateOptions, SuperJSON, ExecutionContext, generateScriptString } from '.';
+import Electron, { WebContents, webFrameMain } from 'electron';
+import { EvaluateOptions, SuperJSON, ExecutionContext, type GenerateScriptOptions, generateScriptString, patchWebFrameMain } from '.';
 
 import superJSONBrowserScript from './superJSON.browser.js?raw';
 
@@ -171,6 +171,12 @@ export interface ExposeFunctionOptions {
      * Default: `true`
      */
     overwrite?: boolean;
+
+    /**
+     * Script generation options applied when this exposed function installs or
+     * updates its browser-side bridge.
+     */
+    script?: Omit<GenerateScriptOptions, 'session'>;
 }
 
 const kAwaitCompletionSymbol = Symbol('awaitCompletion');
@@ -309,12 +315,12 @@ export interface SessionOptions {
 
     /**
      * Whether to automatically attach to related targets.
-     * 
+     *
      * default: `undefined`
-     * 
+     *
      * - `false`, `undefined` : No auto attachment to related targets.
      * - `true` : Auto attachment to related targets.
-     * - `TargetType[]` : Auto attachment to related targets of the specified types.
+     * - `Target['type'][]` : Auto attachment to related targets of the specified types.
      */
     autoAttachToRelatedTargets?: boolean | (Target['type'][]);
 }
@@ -325,9 +331,9 @@ export interface SessionOptions {
 export interface SetAutoAttachOptions {
     /**
      * Target types to attach to.
-     * 
+     *
      * default: `undefined`
-     * 
+     *
      * - `undefined` : Auto attachment to all related targets.
      * - `Target['type'][]` : Auto attachment to related targets of the specified types.
      */
@@ -335,9 +341,9 @@ export interface SetAutoAttachOptions {
 
     /**
      * Whether to attach to related targets recursively.
-     * 
+     *
      * default: `undefined`
-     * 
+     *
      * - `undefined` : Auto attachment to related targets recursively.
      * - `true` : Auto attachment to related targets recursively.
      * - `false` : Auto attachment to related targets not recursively.
@@ -498,12 +504,12 @@ export class Session {
     evaluate<A extends unknown[], R>(options: EvaluateOptions, fn: (...args: A) => R, ...args: A): Promise<R>;
 
     /**
-     * Exposes a function to the browser's global context under the specified name.
+     * Implementation for the `evaluate` overloads.
      *
-     * @param name - The name under which the function will be exposed.
-     * @param fn - The function to expose.
-     * @param options - Optional settings for exposing the function.
-     * @returns A promise that resolves when the function is successfully exposed.
+     * @param fnOrOptions - Function to evaluate, or options followed by the function.
+     * @param fnOrArg0 - Function to evaluate when options are provided, or the first function argument.
+     * @param args - Remaining arguments passed to the evaluated function.
+     * @returns A promise that resolves with the evaluated function result.
      */
     async evaluate<F extends (...args: ARGS) => R, ARG_0, ARGS_OTHER extends unknown[], ARGS extends [ARG_0, ...ARGS_OTHER], R>(
         fnOrOptions: F | EvaluateOptions,
@@ -596,7 +602,7 @@ export class Session {
     /**
      * Enables tracking of execution contexts within the session.
      *
-     * When enabled, the session will listen for execution context lifecycle events (`execution-context-created`, `execution-context-destroyed`, `execution-contexts-cleared)
+     * When enabled, the session will listen for execution context lifecycle events (`execution-context-created`, `execution-context-destroyed`, `execution-contexts-cleared`).
      * and maintain a map of active execution contexts.
      *
      * This method sends the `Runtime.enable` command and starts tracking for all subsequently created execution contexts.
@@ -1007,6 +1013,9 @@ export class Session {
 
         const source = `${superJSONBrowserScript}; (${convertToFunction(this.#customizeSuperJSON.toString())})(SuperJSON.default); (globalThis.$cdp ??= { consoleDebug: console.debug }).superJSON = SuperJSON.default;`;
         try {
+            if ((await this.#domainsPr).some(domain => domain.name === 'Page')) {
+                await this.send('Page.enable');
+            }
             await this.send('Page.addScriptToEvaluateOnNewDocument', { runImmediately: true, source });
         } catch (error) {
             console.error('[Session.enableSuperJSON] Failed to inject code :', error);
@@ -1157,43 +1166,15 @@ export class Session {
         }
     }
 
-    #patchWebFrameMain(frame: WebFrameMain) {
-        if (frame.evaluate !== undefined) {
-            return frame;
-        }
-        frame.evaluate ??= async <A0, A extends unknown[], R>(userGestureOrFn: boolean | ((...args: [A0, ...A]) => R), fnOrArg0: A0 | ((...args: [A0, ...A]) => R), ...args: A): Promise<R> => {
-            try {
-                if (typeof userGestureOrFn === 'boolean') {
-                    return this.superJSON.parse(await (frame.executeJavaScript(generateScriptString({ session: this }, fnOrArg0 as (...args: A) => R, ...args), userGestureOrFn)) as string);
-                } else {
-                    return this.superJSON.parse(await (frame.executeJavaScript(generateScriptString({ session: this }, userGestureOrFn, fnOrArg0 as A0, ...args))) as string);
-                }
-            } catch (error) {
-                if (typeof error === 'string') {
-                    let result;
-                    try {
-                        result = this.superJSON.parse(error);
-                    } catch {
-                    }
-                    if (result) {
-                        throw result;
-                    }
-                }
-                throw error;
-            }
-        };
-        return frame;
-    }
-
     /**
      * Exposes a function to the browser's global context.
      *
      * @param name - The name under which the function will be exposed.
      * @param fn - The function to expose.
      * @param options - Options for exposing the function.
-     * @returns True if the function is exposed successfully, false otherwise.
+     * @returns `true` if the function is exposed successfully, `false` when it is already exposed.
      */
-    async exposeFunction<T, A extends unknown[]>(name: string, fn: (...args: A) => Promise<T> | T, options?: ExposeFunctionOptions) {
+    async exposeFunction<T, A extends unknown[]>(name: string, fn: (...args: A) => Promise<T> | T, options?: ExposeFunctionOptions): Promise<boolean> {
         const id = `expose-function-${crypto.randomUUID()}` as const;
 
         if (options?.overwrite) {
@@ -1370,7 +1351,7 @@ export class Session {
             const timeout = typeof withReturnValue === 'object' ? withReturnValue.timeout : undefined;
             try {
                 if (options?.retry) {
-                    await context.evaluate({ timeout }, (seq) => {
+                    await context.evaluate({ timeout, script: options?.script }, (seq) => {
                         if (globalThis.$cdp?.callback.returnValues && seq in globalThis.$cdp.callback.returnValues) {
                             globalThis.$cdp.callback.returnValues[seq].init = true;
                         }
@@ -1379,7 +1360,7 @@ export class Session {
                 const ret = await fn(...payload.args);
 
                 if (withReturnValue) {
-                    await context.evaluate({ timeout }, (seq, ret) => {
+                    await context.evaluate({ timeout, script: options?.script }, (seq, ret) => {
                         if (globalThis.$cdp?.callback?.returnValues && seq in globalThis.$cdp.callback.returnValues) {
                             globalThis.$cdp.callback.returnValues[seq].value = ret;
                         }
@@ -1388,7 +1369,7 @@ export class Session {
             } catch (error) {
                 if (isUnexceptedError(error)) {
                     if (withReturnValue) {
-                        await context.evaluate({ timeout }, (seq, error) => {
+                        await context.evaluate({ timeout, script: options?.script }, (seq, error) => {
                             if (globalThis.$cdp?.callback?.errors && seq in globalThis.$cdp.callback.errors) {
                                 globalThis.$cdp.callback.errors[seq].value = error;
                             }
@@ -1400,13 +1381,34 @@ export class Session {
 
         const mode = options?.mode ?? 'Electron';
         const withReturnValue = options?.withReturnValue;
-        const timeout = () => new Promise<void>((resolve, reject) => {
+        const withReturnTimeout = async <T>(promise: Promise<T>) => {
             const timeout = typeof withReturnValue === 'object' ? withReturnValue.timeout : undefined;
-            if (timeout) {
-                setTimeout(reject, timeout);
+            if (timeout === undefined) {
+                return promise;
             }
-            resolve();
-        });
+
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            try {
+                return await Promise.race([
+                    promise,
+                    new Promise<never>((_, reject) => {
+                        timeoutId = setTimeout(() => reject(new Error('Operation did not complete before the timeout.')), timeout);
+                    })
+                ]);
+            } finally {
+                if (timeoutId !== undefined) {
+                    clearTimeout(timeoutId);
+                }
+            }
+        };
+
+        const evaluateWithScript = <T, A extends unknown[]>(target: this | Electron.WebFrameMain, fn: (...args: A) => T, ...args: A) => {
+            const evaluateOptions = { script: options?.script };
+            if (target instanceof Session) {
+                return target.evaluate(evaluateOptions, fn, ...args);
+            }
+            return target.evaluate(evaluateOptions, fn, ...args);
+        };
 
         const bindingCalled = (event: Protocol.Runtime.BindingCalledEvent) => {
             try {
@@ -1425,30 +1427,30 @@ export class Session {
 
         const init = async (target: this | Electron.WebFrameMain, sequence: string) => {
             if (options?.retry) {
-                await Promise.race([target.evaluate(seq => {
+                await withReturnTimeout(evaluateWithScript(target, (seq: string) => {
                     if (globalThis.$cdp?.callback.returnValues && seq in globalThis.$cdp.callback.returnValues) {
                         globalThis.$cdp.callback.returnValues[seq].init = true;
                     }
-                }, sequence), timeout()]);
+                }, sequence));
             }
         };
 
         const resolve = async (target: this | Electron.WebFrameMain, sequence: string, result: unknown) => {
             if (withReturnValue) {
-                await Promise.race([target.evaluate((seq, ret) => {
+                await withReturnTimeout(evaluateWithScript(target, (seq: string, ret: unknown) => {
                     if (globalThis.$cdp?.callback.returnValues && seq in globalThis.$cdp.callback.returnValues) {
                         globalThis.$cdp.callback.returnValues[seq].value = ret;
                     }
-                }, sequence, result), timeout()]);
+                }, sequence, result));
             }
         };
         const reject = async (target: this | Electron.WebFrameMain, sequence: string, error: unknown) => {
             if (withReturnValue) {
-                await Promise.race([target.evaluate((seq, error) => {
+                await withReturnTimeout(evaluateWithScript(target, (seq: string, error: unknown) => {
                     if (globalThis.$cdp?.callback?.errors && seq in globalThis.$cdp.callback.errors) {
                         globalThis.$cdp.callback.errors[seq].value = error;
                     }
-                }, sequence, error), timeout()]);
+                }, sequence, error));
             }
         };
 
@@ -1461,7 +1463,7 @@ export class Session {
 
                 const { type, sessionId, frameId, payload: payloadString } = JSON.parse(details.message.substring('cdp-utils-'.length)) as InvokeMessage;
 
-                const frame = this.#patchWebFrameMain(getWebFrameFromFrameId(frameId) ?? details.frame);
+                const frame = patchWebFrameMain(this, getWebFrameFromFrameId(frameId) ?? details.frame);
 
                 if (sessionId !== this.id) {
                     return {};
@@ -1564,7 +1566,7 @@ export class Session {
                 }
                 default:
                     //
-                    // Unsupported Electron target type encountered. 
+                    // Unsupported Electron target type encountered.
                     // Only "service_worker", "page", "iframe", and "worker" are currently handled.
                     //
                     throw new Error(`Electron mode does not support target type: ${targetInfo.type}`);
@@ -1584,17 +1586,18 @@ export class Session {
         let entry;
         try {
             if ((!targetInfo.type.endsWith('worker') && (await this.#domainsPr).some(d => d.name === 'Page'))) {
+                await this.send('Page.enable');
                 const scriptId = (await this.send('Page.addScriptToEvaluateOnNewDocument', {
                     runImmediately: true,
-                    source: generateScriptString({ session: this }, attachFunction, id, name, options, this.id)
+                    source: generateScriptString({ ...options?.script, session: this }, attachFunction, id, name, options, this.id)
                 })).identifier;
                 entry = {
                     scriptId,
-                    attach: () => this.evaluate(attachFunction, id, name, options, this.id),
+                    attach: () => this.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id),
                     removeHandler
                 };
                 this.#exposeFunctions.set(name, entry);
-                return entry;
+                return true;
             }
         } catch (error) {
             logUnexceptedError(error, { type: 'error', message: `[CDP.exposeFunction] Failed to inject code(attachFunction:${name}) :` });
@@ -1611,7 +1614,7 @@ export class Session {
          *   Inject into existing frames immediately, and then hook 'did-frame-navigate'
          *   to avoid touching frame contexts before Electron preload injection.
          */
-        await this.evaluate(attachFunction, id, name, options, this.id)
+        await this.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id)
             .catch(error => {
                 if (isUnexceptedError(error)) {
                     console.error(`[CDP.exposeFunction] Failed to inject code(attachFunction:${name}) :`, error);
@@ -1622,7 +1625,7 @@ export class Session {
 
         if (mode === 'CDP') {
             for (const ctx of this.#executionContexts.values()) {
-                promises.push(ctx.evaluate(attachFunction, id, name, options, this.id).catch(error => {
+                promises.push(ctx.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id).catch(error => {
                     if (isUnexceptedError(error)) {
                         console.error(error);
                     }
@@ -1631,7 +1634,7 @@ export class Session {
 
             const executionContextCreated = async (context: ExecutionContext) => {
                 try {
-                    await context.evaluate(attachFunction, id, name, options, this.id);
+                    await context.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id);
                 } catch (error) {
                     if (isUnexceptedError(error)) {
                         console.error(error);
@@ -1643,13 +1646,13 @@ export class Session {
             this.#emitter.prependListener('execution-context-created', executionContextCreated);
             entry = {
                 executionContextCreated,
-                attach: () => this.evaluate(attachFunction, id, name, options, this.id),
+                attach: () => this.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id),
                 removeHandler
             };
         } else if (this.id === undefined) {
             for (const frame of this.webContents.mainFrame.framesInSubtree) {
-                this.#patchWebFrameMain(frame);
-                promises.push(frame.evaluate(attachFunction, id, name, options, this.id, `${frame.processId}-${frame.routingId}`));
+                patchWebFrameMain(this, frame);
+                promises.push(frame.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id, `${frame.processId}-${frame.routingId}`));
             }
 
             const didFrameNavigate = async (
@@ -1666,8 +1669,8 @@ export class Session {
                     if (!frame) {
                         return;
                     }
-                    this.#patchWebFrameMain(frame);
-                    frame.evaluate(attachFunction, id, name, options, this.id, `${frame.processId}-${frame.routingId}`);
+                    patchWebFrameMain(this, frame);
+                    frame.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id, `${frame.processId}-${frame.routingId}`);
                 } catch (error) {
                     console.error(error);
                 }
@@ -1676,7 +1679,7 @@ export class Session {
             this.webContents.on('did-frame-navigate', didFrameNavigate);
             entry = {
                 didFrameNavigate,
-                attach: () => this.webContents.mainFrame.evaluate(attachFunction, id, name, options, this.id),
+                attach: () => this.webContents.mainFrame.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id),
                 removeHandler
             };
         }
@@ -1684,7 +1687,7 @@ export class Session {
 
 
         entry ??= {
-            attach: () => this.evaluate(attachFunction, id, name, options, this.id),
+            attach: () => this.evaluate({ script: options?.script }, attachFunction, id, name, options, this.id),
             removeHandler
         };
 
@@ -1739,7 +1742,7 @@ export class Session {
         const promises = [];
         if (this.target.type === 'page' || this.target.type === 'iframe') {
             promises.push(...this.webContents.mainFrame.framesInSubtree.map(frame => {
-                this.#patchWebFrameMain(frame);
+                patchWebFrameMain(this, frame);
                 // @ts-expect-error : globalThis[name]
                 return frame.evaluate(name => delete globalThis[name], name);
             }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,16 +3,110 @@ import { Session } from './session';
 import { SuperJSON } from 'superjson';
 
 import superJSONBrowserScript from './superJSON.browser.js?raw';
+import { WebFrameMain } from 'electron';
 
 const FunctionSignature = '_$cdp_fn$_';
 
-export function generateScriptString<T, A extends unknown[]>(options: ({ session?: Session, timeout?: number; }) | undefined, fn: (...args: A) => T, ...args: A) {
+type AnyFunction = (...args: unknown[]) => unknown;
+
+/**
+ * Converts a function into the script body that can be injected before the
+ * generated evaluate wrapper. String values are treated as already-extracted
+ * script bodies so callers can pass raw JavaScript when needed.
+ */
+function getFunctionBody(fn: AnyFunction | string) {
+    if (typeof fn === 'string') return fn;
+
+    const source = Function.prototype.toString.call(fn).trim();
+
+    const start = source.indexOf("{");
+    const end = source.lastIndexOf("}");
+
+    if (start !== -1 && end !== -1 && end > start) {
+        return source.slice(start + 1, end).trim();
+    }
+
+    const arrowIndex = source.indexOf("=>");
+
+    if (arrowIndex !== -1) {
+        return source.slice(arrowIndex + 2).trim();
+    }
+}
+
+/**
+ * Options used to generate the browser-side wrapper script for evaluate calls.
+ */
+export type GenerateScriptOptions = {
+    /**
+     * Session that provides SuperJSON serialization settings and preload state.
+     */
+    session?: Session;
+
+    /**
+     * Maximum wait time, in milliseconds, for a preloaded SuperJSON instance.
+     *
+     * @default 5000
+     */
+    timeout?: number;
+
+    /**
+     * Script body or function body to run before the generated evaluate wrapper setup.
+     */
+    initScript?: (() => void) | string;
+}
+
+/**
+ * Options accepted by `WebFrameMain.evaluate` when its first argument is an object.
+ */
+export type WebFrameEvaluateOptions = Omit<GenerateScriptOptions, 'session'> & {
+    /**
+     * Whether the evaluated code should run as if it was triggered by a user gesture.
+     */
+    userGesture?: boolean;
+
+    /**
+     * Script generation options applied only to this evaluate call.
+     *
+     * This is also accepted as a nested form so callers can share the same
+     * `{ script }` object used by `Session.evaluate`.
+     */
+    script?: Omit<GenerateScriptOptions, 'session'>;
+};
+
+/**
+ * Default options installed by `patchWebFrameMain` for patched frame evaluate calls.
+ */
+export type WebFramePatchOptions = Omit<GenerateScriptOptions, 'session'> & {
+    /**
+     * Replace an existing `evaluate` helper when one is already present on the frame.
+     */
+    overwrite?: boolean;
+};
+
+/**
+ * Builds the JavaScript source evaluated inside a target frame or runtime context.
+ *
+ * The generated wrapper runs `initScript` first, prepares SuperJSON/polyfills,
+ * restores function arguments that were serialized as source text, then invokes
+ * `fn(...args)` and serializes either the result or thrown error back to Node.
+ *
+ * @template T - Return type of the function evaluated in the target context.
+ * @template A - Argument tuple passed to the evaluated function.
+ * @param options - Script generation options.
+ * @param options.session - Session used for SuperJSON customization and serialization.
+ * @param options.timeout - Maximum wait time, in milliseconds, for a preloaded SuperJSON instance.
+ * @param options.initScript - Script body or function body to run before the generated wrapper setup.
+ * @param fn - Function to execute in the target context.
+ * @param args - Arguments passed to `fn`.
+ * @returns JavaScript source string ready to pass to CDP `Runtime.evaluate` or Electron `executeJavaScript`.
+ */
+export function generateScriptString<T, A extends unknown[]>(options: GenerateScriptOptions | undefined, fn: (...args: A) => T, ...args: A) {
     const argsPacked = args.map(arg => (typeof arg === 'function' ? FunctionSignature + arg.toString() : arg));
     const argsCode = argsPacked
         .map((arg, index) =>
             (typeof arg === 'string' && arg.trim().startsWith(FunctionSignature)) ? `args[${index}] = ${arg.substring(FunctionSignature.length).toString()};` : '')
         .join(';\n');
-    return '(async () => {' +
+    return '(async () => {' + `;;${getFunctionBody(options?.initScript ?? '')};;` +
         (options?.session?.isSuperJSONPreloaded ?
             `
             globalThis.$cdp ??= { consoleDebug: console.debug };
@@ -73,4 +167,75 @@ export function generateScriptString<T, A extends unknown[]>(options: ({ session
                 throw globalThis.$cdp.superJSON.stringify(error);
             }
         })();`
+}
+
+/**
+ * Adds the typed `evaluate` helper to an Electron `WebFrameMain`.
+ *
+ * The helper mirrors `executeJavaScript`, but accepts a function plus typed
+ * arguments, serializes values through the session's SuperJSON instance, and
+ * rethrows browser-side errors as parsed JavaScript values when possible.
+ *
+ * @param session - CDP session that owns serialization settings and SuperJSON customizations.
+ * @param frame - Electron frame to patch.
+ * @param options - Default script-generation options for frame evaluate calls. Set `overwrite` to replace an existing helper.
+ * @returns The same frame instance after `evaluate` has been installed.
+ */
+export function patchWebFrameMain(session: Session, frame: WebFrameMain, options?: WebFramePatchOptions) {
+    const { overwrite, ...defaultScriptOptions } = options ?? {};
+
+    const fn = async <R>(...evaluateArgs: unknown[]): Promise<R> => {
+        try {
+            const [firstArg, secondArg, ...args] = evaluateArgs;
+            let userGesture: boolean | undefined;
+            let scriptOptions: Omit<GenerateScriptOptions, 'session'> | undefined = defaultScriptOptions;
+            let targetFn: ((...args: unknown[]) => R) | undefined;
+            let targetArgs: unknown[];
+
+            if (typeof firstArg === 'boolean') {
+                userGesture = firstArg;
+                targetFn = secondArg as ((...args: unknown[]) => R) | undefined;
+                targetArgs = args;
+            } else if (typeof firstArg === 'function') {
+                targetFn = firstArg as (...args: unknown[]) => R;
+                targetArgs = evaluateArgs.slice(1);
+            } else if (firstArg && typeof firstArg === 'object') {
+                const { userGesture: evaluateUserGesture, script, ...inlineScriptOptions } = firstArg as WebFrameEvaluateOptions;
+                userGesture = evaluateUserGesture;
+                scriptOptions = { ...defaultScriptOptions, ...inlineScriptOptions, ...script };
+                targetFn = secondArg as ((...args: unknown[]) => R) | undefined;
+                targetArgs = args;
+            } else {
+                throw new Error('invalid parameter');
+            }
+
+            if (typeof targetFn !== 'function') {
+                throw new TypeError('invalid parameter');
+            }
+
+            const source = generateScriptString({ ...scriptOptions, session }, targetFn, ...targetArgs);
+            const result = userGesture === undefined
+                ? await frame.executeJavaScript(source)
+                : await frame.executeJavaScript(source, userGesture);
+            return session.superJSON.parse(result as string);
+        } catch (error) {
+            if (typeof error === 'string') {
+                let result;
+                try {
+                    result = session.superJSON.parse(error);
+                } catch {
+                }
+                if (result) {
+                    throw result;
+                }
+            }
+            throw error;
+        }
+    };
+    if (overwrite) {
+        frame.evaluate = fn;
+    } else {
+        frame.evaluate ??= fn;
+    }
+    return frame;
 }

--- a/test/e2e/electron-app.cjs
+++ b/test/e2e/electron-app.cjs
@@ -1,10 +1,52 @@
 const { app, BrowserWindow } = require('electron');
-const { attach } = require('../..');
+const { attach, isAttached } = require('../..');
+
+async function waitFor(read, timeout = 5000) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeout) {
+    const value = read();
+    if (value) {
+      return value;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+
+  throw new Error('Timed out while waiting for e2e condition.');
+}
+
+async function captureError(action) {
+  try {
+    await action();
+    return { threw: false };
+  } catch (error) {
+    return {
+      threw: true,
+      name: error?.name,
+      message: error?.message,
+      description: error?.description,
+      text: error?.text,
+      code: error?.code,
+      string: String(error),
+      keys: error && typeof error === 'object' ? Object.keys(error).sort() : [],
+    };
+  }
+}
 
 function debug(message) {
   if (process.env.ELECTRON_CDP_E2E_DEBUG) {
     console.error(`[e2e] ${message}`);
   }
+}
+
+function pageUrl(body, title = 'electron-cdp-utils e2e') {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(`
+    <!doctype html>
+    <html>
+      <head><title>${title}</title></head>
+      ${body}
+    </html>
+  `)}`;
 }
 
 async function main() {
@@ -23,50 +65,319 @@ async function main() {
     },
   });
 
+  const results = {};
+
   debug('attach session');
+  results.attach = {
+    before: isAttached(window.webContents),
+  };
   const session = attach(window.webContents, '1.3');
+  results.attach.after = isAttached(window.webContents);
+  results.attach.webContentsGetter = window.webContents.cdp === session;
 
   debug('load page');
-  await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(`
-    <!doctype html>
-    <html>
-      <head><title>electron-cdp-utils e2e</title></head>
-      <body data-ready="yes"></body>
-    </html>
-  `)}`);
+  await window.loadURL(pageUrl('<body data-ready="yes"></body>'));
 
   debug('setup session');
   await session.setup({
+    initScript: 'globalThis.__setupFrameScriptRuns = (globalThis.__setupFrameScriptRuns ?? 0) + 1;',
     preloadSuperJSON: true,
+    timeout: 1000,
     trackExecutionContexts: true,
   });
 
-  debug('evaluate title');
-  const title = await session.evaluate(() => document.title);
-  if (title !== 'electron-cdp-utils e2e') {
-    throw new Error(`Unexpected title: ${title}`);
-  }
+  const targetInfo = await session.getTargetInfo();
+  const domains = await session.getDomains();
+  results.setup = {
+    isSuperJSONPreloaded: session.isSuperJSONPreloaded,
+    trackExecutionContextsEnabled: session.trackExecutionContextsEnabled,
+    targetType: targetInfo.type,
+    hasRuntimeDomain: domains.some(domain => domain.name === 'Runtime'),
+    hasPageDomain: domains.some(domain => domain.name === 'Page'),
+  };
+
+  debug('send raw CDP command');
+  const rawTitle = await session.send('Runtime.evaluate', {
+    expression: 'document.title',
+    returnByValue: true,
+  });
+  results.rawSend = {
+    title: rawTitle.result.value,
+  };
+
+  debug('evaluate basic session calls');
+  const returnedComplex = await session.evaluate(() => ({
+    date: new Date('2024-01-02T03:04:05.000Z'),
+    map: new Map([['alpha', 1], ['beta', 2]]),
+    set: new Set(['red', 'blue']),
+    big: 9007199254740993n,
+  }));
+
+  results.sessionEvaluate = {
+    title: await session.evaluate(() => document.title),
+    args: await session.evaluate((a, b) => a + b, 19, 23),
+    asyncValue: await session.evaluate(async value => value * 2, 21),
+    functionArg: await session.evaluate((value, transform) => transform(value), 7, value => value * 6),
+    undefinedResult: await session.evaluate(() => undefined) === undefined,
+    complexArg: await session.evaluate(payload => ({
+      dateIsDate: payload.date instanceof Date,
+      dateIso: payload.date.toISOString(),
+      mapEntries: Array.from(payload.map.entries()),
+      setValues: Array.from(payload.set.values()).sort(),
+      big: payload.big.toString(),
+      errorMessage: payload.error.message,
+    }), {
+      date: new Date('2023-05-06T07:08:09.000Z'),
+      map: new Map([['one', 1], ['two', 2]]),
+      set: new Set(['b', 'a']),
+      big: 12345678901234567890n,
+      error: new Error('complex-error'),
+    }),
+    complexReturn: {
+      dateIsDate: returnedComplex.date instanceof Date,
+      dateIso: returnedComplex.date.toISOString(),
+      mapEntries: Array.from(returnedComplex.map.entries()),
+      setValues: Array.from(returnedComplex.set.values()).sort(),
+      big: returnedComplex.big.toString(),
+    },
+    scriptRuns: await session.evaluate(
+      {
+        script: {
+          initScript: 'globalThis.__sessionEvaluateScriptRuns = (globalThis.__sessionEvaluateScriptRuns ?? 0) + 1;',
+        },
+      },
+      () => globalThis.__sessionEvaluateScriptRuns,
+    ),
+    functionInitScriptValue: await session.evaluate(
+      {
+        script: {
+          initScript() {
+            globalThis.__sessionFunctionInitScriptValue = 'from-function';
+          },
+        },
+      },
+      () => globalThis.__sessionFunctionInitScriptValue,
+    ),
+    thrown: await captureError(() => session.evaluate(() => {
+      const error = new Error('session-evaluate-failure');
+      error.code = 'E_SESSION_EVALUATE';
+      throw error;
+    })),
+  };
+
+  debug('evaluate tracked execution context');
+  const executionContext = await waitFor(() =>
+    Array.from(session.executionContexts.values()).find(context => context.id),
+  );
+  results.executionContext = {
+    trackedCount: session.executionContexts.size,
+    hasId: typeof executionContext.id === 'number',
+    title: await executionContext.evaluate(() => document.title),
+    args: await executionContext.evaluate((left, right) => `${left}:${right}`, 'ctx', 42),
+    scriptRuns: await executionContext.evaluate(
+      {
+        script: {
+          initScript: 'globalThis.__contextEvaluateScriptRuns = (globalThis.__contextEvaluateScriptRuns ?? 0) + 1;',
+        },
+      },
+      () => globalThis.__contextEvaluateScriptRuns,
+    ),
+  };
 
   debug('evaluate main frame');
-  const frameValue = await window.webContents.mainFrame.evaluate(() => document.body.dataset.ready);
-  if (frameValue !== 'yes') {
-    throw new Error(`Unexpected frame value: ${frameValue}`);
-  }
+  const frameReturnedComplex = await window.webContents.mainFrame.evaluate(() => ({
+    date: new Date('2025-02-03T04:05:06.000Z'),
+    map: new Map([['frame', 1]]),
+    set: new Set(['main', 'frame']),
+  }));
+  results.frameEvaluate = {
+    defaultRuns: await window.webContents.mainFrame.evaluate(
+      () => globalThis.__setupFrameScriptRuns,
+    ),
+    args: await window.webContents.mainFrame.evaluate((a, b) => a * b, 6, 7),
+    complexReturn: {
+      dateIsDate: frameReturnedComplex.date instanceof Date,
+      dateIso: frameReturnedComplex.date.toISOString(),
+      mapEntries: Array.from(frameReturnedComplex.map.entries()),
+      setValues: Array.from(frameReturnedComplex.set.values()).sort(),
+    },
+    inlineScript: await window.webContents.mainFrame.evaluate(
+      {
+        initScript: 'globalThis.__frameInlineScriptValue = "inline";',
+      },
+      () => ({
+        value: globalThis.__frameInlineScriptValue,
+        setupRuns: globalThis.__setupFrameScriptRuns,
+      }),
+    ),
+    nestedScript: await window.webContents.mainFrame.evaluate(
+      {
+        script: {
+          initScript: 'globalThis.__frameNestedScriptValue = "nested";',
+        },
+      },
+      () => ({
+        value: globalThis.__frameNestedScriptValue,
+        setupRuns: globalThis.__setupFrameScriptRuns,
+      }),
+    ),
+    defaultRunsAfterOverrides: await window.webContents.mainFrame.evaluate(
+      () => globalThis.__setupFrameScriptRuns,
+    ),
+    booleanUserGestureFalse: await window.webContents.mainFrame.evaluate(
+      false,
+      () => 'boolean-false',
+    ),
+    optionsUserGestureTrue: await window.webContents.mainFrame.evaluate(
+      {
+        userGesture: true,
+        script: {
+          initScript: 'globalThis.__frameGestureScriptValue = "gesture";',
+        },
+      },
+      () => globalThis.__frameGestureScriptValue,
+    ),
+  };
 
-  debug('expose function');
+  debug('create and evaluate child frame');
+  await session.evaluate(() => new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.id = 'child-frame';
+    iframe.srcdoc = '<!doctype html><html><body data-ready="child"></body></html>';
+    iframe.onload = () => resolve(true);
+    document.body.append(iframe);
+  }));
+
+  const mainFrame = window.webContents.mainFrame;
+  const childFrame = await waitFor(() => mainFrame.framesInSubtree.find(frame =>
+    frame !== mainFrame &&
+    !frame.isDestroyed() &&
+    typeof frame.evaluate === 'function',
+  ));
+
+  results.childFrame = await childFrame.evaluate(() => ({
+    ready: document.body.dataset.ready,
+    setupRuns: globalThis.__setupFrameScriptRuns,
+  }));
+
+  debug('expose functions');
+  results.exposeFunction = {};
+  let recordedValue;
+  await session.exposeFunction('recordNativeCall', value => {
+    recordedValue = value;
+  });
+  await session.evaluate(() => globalThis.recordNativeCall('recorded'));
+  await waitFor(() => recordedValue === 'recorded');
+  results.exposeFunction.noReturnValue = recordedValue;
+
+  await session.exposeFunction('native.tools.join', (...parts) => parts.join(':'), {
+    withReturnValue: { timeout: 1000 },
+  });
+  results.exposeFunction.nestedName = await session.evaluate(async () =>
+    globalThis.native.tools.join('a', 'b', 'c'),
+  );
+
+  await session.exposeFunction('replaceValue', () => 'first', {
+    withReturnValue: { timeout: 1000 },
+  });
+  const firstReplaceValue = await session.evaluate(async () => globalThis.replaceValue());
+  const duplicateExposeResult = await session.exposeFunction('replaceValue', () => 'duplicate', {
+    withReturnValue: { timeout: 1000 },
+  });
+  const stillFirstReplaceValue = await session.evaluate(async () => globalThis.replaceValue());
+  const beforeRemoveExposed = session.isFunctionExposed('replaceValue');
+  await session.exposeFunction('replaceValue', () => 'second', {
+    overwrite: true,
+    withReturnValue: { timeout: 1000 },
+  });
+  const secondReplaceValue = await session.evaluate(async () => globalThis.replaceValue());
+  const removeResult = await session.removeExposedFunction('replaceValue');
+  const afterRemoveExposed = session.isFunctionExposed('replaceValue');
+  const typeAfterRemove = await session.evaluate(() => typeof globalThis.replaceValue);
+  results.exposeFunction.overwriteAndRemove = {
+    first: firstReplaceValue,
+    duplicateResult: duplicateExposeResult,
+    stillFirst: stillFirstReplaceValue,
+    beforeRemoveExposed,
+    second: secondReplaceValue,
+    removeResult,
+    afterRemoveExposed,
+    typeAfterRemove,
+  };
+
+  debug('expose function in Electron mode');
   await session.exposeFunction('nativeAdd', (a, b) => a + b, {
+    script: {
+      initScript: 'globalThis.__electronExposeScriptRuns = (globalThis.__electronExposeScriptRuns ?? 0) + 1;',
+    },
     withReturnValue: { timeout: 1000 },
   });
 
-  debug('call exposed function');
-  const sum = await session.evaluate(async () => globalThis.nativeAdd(20, 22));
-  if (sum !== 42) {
-    throw new Error(`Unexpected exposed function result: ${sum}`);
-  }
+  results.exposeFunction.electronMode = await session.evaluate(async () => {
+    const sum = await globalThis.nativeAdd(20, 22);
+    return {
+      sum,
+      scriptRuns: globalThis.__electronExposeScriptRuns,
+    };
+  });
+
+  debug('expose function in CDP mode');
+  await session.exposeFunction('nativeMultiply', (a, b) => a * b, {
+    mode: 'CDP',
+    script: {
+      initScript: 'globalThis.__cdpExposeScriptRuns = (globalThis.__cdpExposeScriptRuns ?? 0) + 1;',
+    },
+    withReturnValue: { timeout: 1000 },
+  });
+
+  results.exposeFunction.cdpMode = await session.evaluate(async () => {
+    const product = await globalThis.nativeMultiply(6, 7);
+    return {
+      product,
+      scriptRuns: globalThis.__cdpExposeScriptRuns,
+    };
+  });
+
+  await session.exposeFunction('nativeThrow', () => {
+    throw new Error('native-throw-failure');
+  }, {
+    script: {
+      initScript: 'globalThis.__nativeThrowScriptRuns = (globalThis.__nativeThrowScriptRuns ?? 0) + 1;',
+    },
+    withReturnValue: { timeout: 1000 },
+  });
+  results.exposeFunction.thrown = await captureError(() =>
+    session.evaluate(async () => globalThis.nativeThrow()),
+  );
+  results.exposeFunction.throwScriptRuns = await session.evaluate(() => globalThis.__nativeThrowScriptRuns);
+
+  debug('navigate and verify setup/exposed functions remain installed');
+  await window.loadURL(pageUrl('<body data-ready="after-navigation"></body>', 'electron-cdp-utils e2e navigated'));
+  results.afterNavigation = {
+    frame: await window.webContents.mainFrame.evaluate(() => ({
+      title: document.title,
+      ready: document.body.dataset.ready,
+      setupRuns: globalThis.__setupFrameScriptRuns,
+    })),
+    exposedFunctions: await session.evaluate(async () => ({
+      addType: typeof globalThis.nativeAdd,
+      multiplyType: typeof globalThis.nativeMultiply,
+      sum: await globalThis.nativeAdd(1, 2),
+      product: await globalThis.nativeMultiply(3, 4),
+      electronScriptRuns: globalThis.__electronExposeScriptRuns,
+      cdpScriptRuns: globalThis.__cdpExposeScriptRuns,
+    })),
+  };
 
   debug('detach and close');
   await session.detach();
+  results.detach = {
+    debuggerAttached: window.webContents.debugger.isAttached(),
+  };
   await window.close();
+  await new Promise(resolve => {
+    process.stdout.write(`E2E_RESULT ${JSON.stringify(results)}\n`, resolve);
+  });
 }
 
 main()

--- a/test/e2e/electron.test.cjs
+++ b/test/e2e/electron.test.cjs
@@ -5,10 +5,14 @@ const test = require('node:test');
 
 const electronPath = require('electron');
 
-test('Electron integration evaluates page code and exposed functions', { timeout: 15000 }, async (t) => {
+function assertThrown(errorResult) {
+  assert.equal(errorResult.threw, true);
+}
+
+async function runElectronApp(t) {
   if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
     t.skip('Electron e2e requires DISPLAY or WAYLAND_DISPLAY on Linux.');
-    return;
+    return undefined;
   }
 
   const appPath = path.join(__dirname, 'electron-app.cjs');
@@ -39,4 +43,145 @@ test('Electron integration evaluates page code and exposed functions', { timeout
   });
 
   assert.equal(exitCode, 0, `Electron e2e failed.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+
+  const resultLine = stdout
+    .split(/\r?\n/)
+    .find(line => line.startsWith('E2E_RESULT '));
+
+  assert.ok(resultLine, `Electron e2e did not report results.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+
+  return JSON.parse(resultLine.slice('E2E_RESULT '.length));
+}
+
+test('Electron integration covers session, frame, context, and exposed-function contracts', { timeout: 15000 }, async (t) => {
+  const result = await runElectronApp(t);
+  if (!result) {
+    return;
+  }
+
+  await t.test('attach and setup contracts', () => {
+    assert.deepEqual(result.attach, {
+      before: false,
+      after: true,
+      webContentsGetter: true,
+    });
+
+    assert.deepEqual(result.setup, {
+      isSuperJSONPreloaded: true,
+      trackExecutionContextsEnabled: true,
+      targetType: 'page',
+      hasRuntimeDomain: true,
+      hasPageDomain: true,
+    });
+
+    assert.deepEqual(result.rawSend, {
+      title: 'electron-cdp-utils e2e',
+    });
+  });
+
+  await t.test('Session.evaluate contracts', () => {
+    assert.equal(result.sessionEvaluate.title, 'electron-cdp-utils e2e');
+    assert.equal(result.sessionEvaluate.args, 42);
+    assert.equal(result.sessionEvaluate.asyncValue, 42);
+    assert.equal(result.sessionEvaluate.functionArg, 42);
+    assert.equal(result.sessionEvaluate.undefinedResult, true);
+    assert.deepEqual(result.sessionEvaluate.complexArg, {
+      dateIsDate: true,
+      dateIso: '2023-05-06T07:08:09.000Z',
+      mapEntries: [['one', 1], ['two', 2]],
+      setValues: ['a', 'b'],
+      big: '12345678901234567890',
+      errorMessage: 'complex-error',
+    });
+    assert.deepEqual(result.sessionEvaluate.complexReturn, {
+      dateIsDate: true,
+      dateIso: '2024-01-02T03:04:05.000Z',
+      mapEntries: [['alpha', 1], ['beta', 2]],
+      setValues: ['blue', 'red'],
+      big: '9007199254740993',
+    });
+    assert.equal(result.sessionEvaluate.scriptRuns, 1);
+    assert.equal(result.sessionEvaluate.functionInitScriptValue, 'from-function');
+    assertThrown(result.sessionEvaluate.thrown);
+  });
+
+  await t.test('ExecutionContext.evaluate contracts', () => {
+    assert.ok(result.executionContext.trackedCount >= 1);
+    assert.equal(result.executionContext.hasId, true);
+    assert.equal(result.executionContext.title, 'electron-cdp-utils e2e');
+    assert.equal(result.executionContext.args, 'ctx:42');
+    assert.equal(result.executionContext.scriptRuns, 1);
+  });
+
+  await t.test('WebFrameMain.evaluate contracts', () => {
+    assert.equal(result.frameEvaluate.defaultRuns, 2);
+    assert.equal(result.frameEvaluate.args, 42);
+    assert.deepEqual(result.frameEvaluate.complexReturn, {
+      dateIsDate: true,
+      dateIso: '2025-02-03T04:05:06.000Z',
+      mapEntries: [['frame', 1]],
+      setValues: ['frame', 'main'],
+    });
+    assert.deepEqual(result.frameEvaluate.inlineScript, {
+      value: 'inline',
+      setupRuns: 3,
+    });
+    assert.deepEqual(result.frameEvaluate.nestedScript, {
+      value: 'nested',
+      setupRuns: 3,
+    });
+    assert.equal(result.frameEvaluate.defaultRunsAfterOverrides, 4);
+    assert.equal(result.frameEvaluate.booleanUserGestureFalse, 'boolean-false');
+    assert.equal(result.frameEvaluate.optionsUserGestureTrue, 'gesture');
+
+    assert.deepEqual(result.childFrame, {
+      ready: 'child',
+      setupRuns: 1,
+    });
+  });
+
+  await t.test('exposeFunction contracts', () => {
+    assert.equal(result.exposeFunction.noReturnValue, 'recorded');
+    assert.equal(result.exposeFunction.nestedName, 'a:b:c');
+    assert.deepEqual(result.exposeFunction.overwriteAndRemove, {
+      first: 'first',
+      duplicateResult: false,
+      stillFirst: 'first',
+      beforeRemoveExposed: true,
+      second: 'second',
+      removeResult: true,
+      afterRemoveExposed: false,
+      typeAfterRemove: 'undefined',
+    });
+    assert.deepEqual(result.exposeFunction.electronMode, {
+      sum: 42,
+      scriptRuns: 2,
+    });
+    assert.deepEqual(result.exposeFunction.cdpMode, {
+      product: 42,
+      scriptRuns: 2,
+    });
+    assertThrown(result.exposeFunction.thrown);
+    assert.equal(result.exposeFunction.throwScriptRuns, 2);
+  });
+
+  await t.test('navigation and detach contracts', () => {
+    assert.deepEqual(result.afterNavigation.frame, {
+      title: 'electron-cdp-utils e2e navigated',
+      ready: 'after-navigation',
+      setupRuns: 1,
+    });
+    assert.deepEqual(result.afterNavigation.exposedFunctions, {
+      addType: 'function',
+      multiplyType: 'function',
+      sum: 3,
+      product: 12,
+      electronScriptRuns: 2,
+      cdpScriptRuns: 2,
+    });
+
+    assert.deepEqual(result.detach, {
+      debuggerAttached: false,
+    });
+  });
 });

--- a/test/mock/session.test.cjs
+++ b/test/mock/session.test.cjs
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const test = require('node:test');
 
-const { ExecutionContext, Session, attach, isAttached } = require('../..');
+const { ExecutionContext, Session, attach, isAttached, patchWebFrameMain } = require('../..');
 
 class MockDebugger extends EventEmitter {
   constructor() {
@@ -122,6 +122,203 @@ test('ExecutionContext.evaluate sends Runtime.evaluate and parses SuperJSON resu
   assert.equal(command.params.awaitPromise, true);
   assert.equal(command.params.returnByValue, false);
   assert.match(command.params.expression, /const fn = \(a, b\) =>/);
+});
+
+test('ExecutionContext.evaluate keeps script options out of Runtime.evaluate params', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  webContents.debugger.runtimeEvaluateResult = {
+    result: {
+      value: session.superJSON.stringify('ready'),
+    },
+  };
+
+  const context = new ExecutionContext(session, 9);
+  const actual = await context.evaluate(
+    {
+      timeout: 1234,
+      script: {
+        initScript: 'globalThis.__contextEvaluateScript = true;',
+      },
+    },
+    () => 'ready',
+  );
+
+  assert.equal(actual, 'ready');
+
+  const command = webContents.debugger.commands.findLast(({ method }) => method === 'Runtime.evaluate');
+  assert.equal(command.params.contextId, 9);
+  assert.equal(command.params.timeout, 1234);
+  assert.equal('script' in command.params, false);
+  assert.match(command.params.expression, /__contextEvaluateScript/);
+});
+
+test('WebFrameMain.evaluate accepts options object with userGesture and script options', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  const calls = [];
+  const frame = {
+    executeJavaScript: async (...callArgs) => {
+      calls.push(callArgs);
+      return session.superJSON.stringify({ ok: true });
+    },
+  };
+
+  patchWebFrameMain(session, frame);
+
+  const actual = await frame.evaluate(
+    {
+      userGesture: true,
+      initScript: 'globalThis.__frameEvaluateOption = true;',
+    },
+    () => ({ ok: globalThis.__frameEvaluateOption === true }),
+  );
+
+  assert.deepEqual(actual, { ok: true });
+  assert.equal(calls[0].length, 2);
+  assert.equal(calls[0][1], true);
+  assert.match(calls[0][0], /__frameEvaluateOption/);
+});
+
+test('WebFrameMain.evaluate preserves boolean userGesture overload', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  const calls = [];
+  const frame = {
+    executeJavaScript: async (...callArgs) => {
+      calls.push(callArgs);
+      return session.superJSON.stringify('ok');
+    },
+  };
+
+  patchWebFrameMain(session, frame);
+
+  const actual = await frame.evaluate(false, () => 'ok');
+
+  assert.equal(actual, 'ok');
+  assert.equal(calls[0].length, 2);
+  assert.equal(calls[0][1], false);
+});
+
+test('WebFrameMain.evaluate omits userGesture when it is not provided', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  const calls = [];
+  const frame = {
+    executeJavaScript: async (...callArgs) => {
+      calls.push(callArgs);
+      return session.superJSON.stringify('ok');
+    },
+  };
+
+  patchWebFrameMain(session, frame);
+
+  const actual = await frame.evaluate(() => 'ok');
+
+  assert.equal(actual, 'ok');
+  assert.equal(calls[0].length, 1);
+});
+
+test('WebFrameMain.evaluate applies patch defaults and lets per-call script override them', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  const calls = [];
+  const frame = {
+    executeJavaScript: async (...callArgs) => {
+      calls.push(callArgs);
+      return session.superJSON.stringify('ok');
+    },
+  };
+
+  patchWebFrameMain(session, frame, {
+    initScript: 'globalThis.__defaultFrameScript = true;',
+  });
+
+  await frame.evaluate(() => 'ok');
+  await frame.evaluate(
+    {
+      script: {
+        initScript: 'globalThis.__overrideFrameScript = true;',
+      },
+    },
+    () => 'ok',
+  );
+
+  assert.match(calls[0][0], /__defaultFrameScript/);
+  assert.doesNotMatch(calls[0][0], /__overrideFrameScript/);
+  assert.match(calls[1][0], /__overrideFrameScript/);
+  assert.doesNotMatch(calls[1][0], /__defaultFrameScript/);
+});
+
+test('patchWebFrameMain respects overwrite option', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  const existingEvaluate = async () => 'existing';
+  const frame = {
+    evaluate: existingEvaluate,
+    executeJavaScript: async () => session.superJSON.stringify('patched'),
+  };
+
+  patchWebFrameMain(session, frame);
+  assert.equal(frame.evaluate, existingEvaluate);
+  assert.equal(await frame.evaluate(), 'existing');
+
+  patchWebFrameMain(session, frame, { overwrite: true });
+  assert.notEqual(frame.evaluate, existingEvaluate);
+  assert.equal(await frame.evaluate(() => 'patched'), 'patched');
+});
+
+test('MainSession.setup applies frame evaluate script defaults to existing and created frames', async () => {
+  const webContents = createMockWebContents();
+  const frameCalls = [];
+  let session;
+  webContents.mainFrame.executeJavaScript = async (...callArgs) => {
+    frameCalls.push(callArgs);
+    return callArgs[0].includes('const fn =') ? session.superJSON.stringify('main') : undefined;
+  };
+
+  session = attach(webContents);
+  await session.setup({
+    initScript: 'globalThis.__setupFrameScript = true;',
+    timeout: 4321,
+  });
+
+  assert.equal(await webContents.mainFrame.evaluate(() => 'main'), 'main');
+
+  const mainEvaluateCall = frameCalls.find(([source]) => source.includes('const fn ='));
+  assert.match(mainEvaluateCall[0], /__setupFrameScript/);
+
+  const childCalls = [];
+  const childFrame = {
+    processId: 3,
+    routingId: 4,
+    framesInSubtree: [],
+    isDestroyed: () => false,
+    executeJavaScript: async (...callArgs) => {
+      childCalls.push(callArgs);
+      return session.superJSON.stringify('child');
+    },
+  };
+
+  webContents.emit('frame-created', {}, { frame: childFrame });
+
+  assert.equal(await childFrame.evaluate(() => 'child'), 'child');
+  assert.match(childCalls[0][0], /__setupFrameScript/);
+});
+
+test('Session.exposeFunction applies script options to browser bridge injection', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+
+  await session.exposeFunction('nativeFromMock', () => undefined, {
+    script: {
+      initScript: 'globalThis.__exposeFunctionScript = true;',
+    },
+  });
+
+  const command = webContents.debugger.commands.findLast(({ method }) => method === 'Page.addScriptToEvaluateOnNewDocument');
+
+  assert.match(command.params.source, /__exposeFunctionScript/);
 });
 
 test('ExecutionContext.evaluate converts CDP exception details into thrown objects', async () => {


### PR DESCRIPTION
## Summary
- add script-generation options for Session/ExecutionContext/WebFrameMain evaluation flows
- apply exposeFunction script options across bridge install/update paths and fix return-value timeout handling
- expand mock/e2e coverage, run build before npm test, and update README/API docs

## Tests
- npm run test
- npx tsc --noEmit --pretty false
- npm run lint:es
- npm run lint:ox