### PR TITLE
Apply setup init script to session evaluations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-cdp-utils",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-cdp-utils",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "ISC",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-cdp-utils",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "author": "ntoskrnl7@gmail.com",
   "license": "ISC",
   "main": "index.js",

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -76,9 +76,18 @@ export class MainSession extends CDPSession {
     async setup(options?: { preloadSuperJSON?: boolean | ((superJSON: SuperJSON) => void) } & Omit<GenerateScriptOptions, 'session'> & SessionOptions) {
 
         const promises = [];
-        promises.push(this.applyOptions(options));
+        const { preloadSuperJSON, initScript, timeout, script, ...sessionOptions } = options ?? {};
+        const setupScriptOptions = {
+            ...(initScript === undefined ? {} : { initScript }),
+            ...(timeout === undefined ? {} : { timeout }),
+            ...script
+        };
+        const hasSetupScriptOptions = initScript !== undefined || timeout !== undefined || script !== undefined;
+        promises.push(this.applyOptions({
+            ...sessionOptions,
+            ...(hasSetupScriptOptions ? { script: setupScriptOptions } : {})
+        }));
 
-        const preloadSuperJSON = options?.preloadSuperJSON;
         if (preloadSuperJSON) {
             promises.push(this.enableSuperJSONPreload(typeof preloadSuperJSON === 'boolean' ? undefined : preloadSuperJSON));
         }
@@ -97,8 +106,7 @@ export class MainSession extends CDPSession {
         };
 
         const frameEvaluateOptions: WebFramePatchOptions = {
-            initScript: options?.initScript,
-            timeout: options?.timeout
+            ...setupScriptOptions
         };
 
         const patchFrame = (frame: WebFrameMain | undefined | null) => {

--- a/src/executionContext.ts
+++ b/src/executionContext.ts
@@ -137,7 +137,7 @@ export class ExecutionContext {
     async #evaluate<T, A extends unknown[]>(options: EvaluateOptions | undefined, fn: (...args: A) => T, ...args: A): Promise<T> {
         const { script, ...runtimeOptions } = options ?? {};
         const res = await this.session.send('Runtime.evaluate', {
-            expression: generateScriptString({ ...script, session: this.session }, fn, ...args),
+            expression: generateScriptString({ ...this.session.getScriptOptions(script), session: this.session }, fn, ...args),
             contextId: this.id,
             throwOnSideEffect: false,
             awaitPromise: true,

--- a/src/session.ts
+++ b/src/session.ts
@@ -323,6 +323,13 @@ export interface SessionOptions {
      * - `Target['type'][]` : Auto attachment to related targets of the specified types.
      */
     autoAttachToRelatedTargets?: boolean | (Target['type'][]);
+
+    /**
+     * Default script generation options applied to Session.evaluate,
+     * ExecutionContext.evaluate, exposeFunction bridge injection, and patched
+     * WebFrameMain.evaluate calls.
+     */
+    script?: Omit<GenerateScriptOptions, 'session'>;
 }
 
 /**
@@ -374,6 +381,7 @@ export class Session {
     #isSuperJSONPreloaded = false;
     #superJSON: SuperJSON;
     #customizeSuperJSON: CustomizeSuperJSONFunction = () => { };
+    #scriptOptions: Omit<GenerateScriptOptions, 'session'> = {};
 
     readonly #executionContexts: Map<Protocol.Runtime.ExecutionContextId, ExecutionContext> = new Map();
 
@@ -526,6 +534,22 @@ export class Session {
     }
 
     /**
+     * Merges session-level script defaults with per-call script options.
+     *
+     * Per-call options intentionally win so callers can override setup defaults.
+     */
+    getScriptOptions(script?: Omit<GenerateScriptOptions, 'session'>) {
+        return { ...this.#scriptOptions, ...script };
+    }
+
+    /**
+     * Configures default script-generation options for this session.
+     */
+    setScriptOptions(script?: Omit<GenerateScriptOptions, 'session'>) {
+        this.#scriptOptions = { ...script };
+    }
+
+    /**
      * Attaches to a specific DevTools Protocol target and returns a Session
      * scoped to that target's dedicated CDP session.
      *
@@ -589,6 +613,9 @@ export class Session {
      */
     async applyOptions(options?: Omit<SessionOptions, 'protocolVersion'>) {
         const promises = [];
+        if (options?.script) {
+            this.#scriptOptions = this.getScriptOptions(options.script);
+        }
         if (options?.autoAttachToRelatedTargets) {
             promises.push(this.setAutoAttach({ recursive: options.autoAttachToRelatedTargets !== undefined, targetTypes: options.autoAttachToRelatedTargets === true ? undefined : options.autoAttachToRelatedTargets }));
         }
@@ -762,6 +789,7 @@ export class Session {
                 const session = await Session.fromSessionId(this.webContents, sessionId);
                 try {
                     session.#parent = this;
+                    session.#scriptOptions = { ...this.#scriptOptions };
 
                     attachedSessions.set(sessionId, session);
 
@@ -1589,7 +1617,7 @@ export class Session {
                 await this.send('Page.enable');
                 const scriptId = (await this.send('Page.addScriptToEvaluateOnNewDocument', {
                     runImmediately: true,
-                    source: generateScriptString({ ...options?.script, session: this }, attachFunction, id, name, options, this.id)
+                    source: generateScriptString({ ...this.getScriptOptions(options?.script), session: this }, attachFunction, id, name, options, this.id)
                 })).identifier;
                 entry = {
                     scriptId,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,7 +188,7 @@ export function patchWebFrameMain(session: Session, frame: WebFrameMain, options
         try {
             const [firstArg, secondArg, ...args] = evaluateArgs;
             let userGesture: boolean | undefined;
-            let scriptOptions: Omit<GenerateScriptOptions, 'session'> | undefined = defaultScriptOptions;
+            let scriptOptions: Omit<GenerateScriptOptions, 'session'> | undefined = session.getScriptOptions(defaultScriptOptions);
             let targetFn: ((...args: unknown[]) => R) | undefined;
             let targetArgs: unknown[];
 
@@ -202,7 +202,7 @@ export function patchWebFrameMain(session: Session, frame: WebFrameMain, options
             } else if (firstArg && typeof firstArg === 'object') {
                 const { userGesture: evaluateUserGesture, script, ...inlineScriptOptions } = firstArg as WebFrameEvaluateOptions;
                 userGesture = evaluateUserGesture;
-                scriptOptions = { ...defaultScriptOptions, ...inlineScriptOptions, ...script };
+                scriptOptions = session.getScriptOptions({ ...defaultScriptOptions, ...inlineScriptOptions, ...script });
                 targetFn = secondArg as ((...args: unknown[]) => R) | undefined;
                 targetArgs = args;
             } else {

--- a/test/e2e/electron.test.cjs
+++ b/test/e2e/electron.test.cjs
@@ -114,7 +114,7 @@ test('Electron integration covers session, frame, context, and exposed-function 
   });
 
   await t.test('WebFrameMain.evaluate contracts', () => {
-    assert.equal(result.frameEvaluate.defaultRuns, 2);
+    assert.equal(result.frameEvaluate.defaultRuns, 10);
     assert.equal(result.frameEvaluate.args, 42);
     assert.deepEqual(result.frameEvaluate.complexReturn, {
       dateIsDate: true,
@@ -124,13 +124,13 @@ test('Electron integration covers session, frame, context, and exposed-function 
     });
     assert.deepEqual(result.frameEvaluate.inlineScript, {
       value: 'inline',
-      setupRuns: 3,
+      setupRuns: 11,
     });
     assert.deepEqual(result.frameEvaluate.nestedScript, {
       value: 'nested',
-      setupRuns: 3,
+      setupRuns: 11,
     });
-    assert.equal(result.frameEvaluate.defaultRunsAfterOverrides, 4);
+    assert.equal(result.frameEvaluate.defaultRunsAfterOverrides, 12);
     assert.equal(result.frameEvaluate.booleanUserGestureFalse, 'boolean-false');
     assert.equal(result.frameEvaluate.optionsUserGestureTrue, 'gesture');
 
@@ -169,7 +169,7 @@ test('Electron integration covers session, frame, context, and exposed-function 
     assert.deepEqual(result.afterNavigation.frame, {
       title: 'electron-cdp-utils e2e navigated',
       ready: 'after-navigation',
-      setupRuns: 1,
+      setupRuns: 3,
     });
     assert.deepEqual(result.afterNavigation.exposedFunctions, {
       addType: 'function',

--- a/test/mock/session.test.cjs
+++ b/test/mock/session.test.cjs
@@ -153,6 +153,28 @@ test('ExecutionContext.evaluate keeps script options out of Runtime.evaluate par
   assert.match(command.params.expression, /__contextEvaluateScript/);
 });
 
+test('Session.evaluate applies session-level script defaults', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  await session.applyOptions({
+    script: {
+      initScript: 'globalThis.__sessionDefaultScript = true;',
+    },
+  });
+  webContents.debugger.runtimeEvaluateResult = {
+    result: {
+      value: session.superJSON.stringify('ready'),
+    },
+  };
+
+  const actual = await session.evaluate(() => 'ready');
+
+  assert.equal(actual, 'ready');
+
+  const command = webContents.debugger.commands.findLast(({ method }) => method === 'Runtime.evaluate');
+  assert.match(command.params.expression, /__sessionDefaultScript/);
+});
+
 test('WebFrameMain.evaluate accepts options object with userGesture and script options', async () => {
   const webContents = createMockWebContents();
   const session = new Session(webContents);
@@ -217,6 +239,26 @@ test('WebFrameMain.evaluate omits userGesture when it is not provided', async ()
 
   assert.equal(actual, 'ok');
   assert.equal(calls[0].length, 1);
+});
+
+test('WebFrameMain.evaluate applies session-level script defaults', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  session.setScriptOptions({
+    initScript: 'globalThis.__frameSessionDefaultScript = true;',
+  });
+  const calls = [];
+  const frame = {
+    executeJavaScript: async (...callArgs) => {
+      calls.push(callArgs);
+      return session.superJSON.stringify('ok');
+    },
+  };
+
+  patchWebFrameMain(session, frame);
+
+  assert.equal(await frame.evaluate(() => 'ok'), 'ok');
+  assert.match(calls[0][0], /__frameSessionDefaultScript/);
 });
 
 test('WebFrameMain.evaluate applies patch defaults and lets per-call script override them', async () => {
@@ -319,6 +361,62 @@ test('Session.exposeFunction applies script options to browser bridge injection'
   const command = webContents.debugger.commands.findLast(({ method }) => method === 'Page.addScriptToEvaluateOnNewDocument');
 
   assert.match(command.params.source, /__exposeFunctionScript/);
+});
+
+test('Session.exposeFunction applies session-level script defaults', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  session.setScriptOptions({
+    initScript: 'globalThis.__exposeFunctionDefaultScript = true;',
+  });
+
+  await session.exposeFunction('nativeDefaultFromMock', () => undefined);
+
+  const command = webContents.debugger.commands.findLast(({ method }) => method === 'Page.addScriptToEvaluateOnNewDocument');
+
+  assert.match(command.params.source, /__exposeFunctionDefaultScript/);
+});
+
+test('auto-attached sessions inherit session-level script defaults', async () => {
+  const webContents = createMockWebContents();
+  const session = new Session(webContents);
+  await session.applyOptions({
+    script: {
+      initScript: 'globalThis.__attachedSessionDefaultScript = true;',
+    },
+  });
+
+  let attachedSession;
+  session.on('session-attached', childSession => {
+    attachedSession = childSession;
+  });
+
+  await session.setAutoAttach();
+  webContents.debugger.emit('message', {}, 'Target.attachedToTarget', {
+    sessionId: 'child-session',
+    targetInfo: {
+      targetId: 'worker-target',
+      type: 'worker',
+      title: 'Mock worker',
+      url: 'https://example.test/worker.js',
+      attached: true,
+      canAccessOpener: false,
+    },
+  });
+  await new Promise(resolve => setTimeout(resolve, 20));
+
+  assert.ok(attachedSession);
+  webContents.debugger.runtimeEvaluateResult = {
+    result: {
+      value: attachedSession.superJSON.stringify('ok'),
+    },
+  };
+
+  assert.equal(await attachedSession.evaluate(() => 'ok'), 'ok');
+
+  const command = webContents.debugger.commands.findLast(({ method }) => method === 'Runtime.evaluate');
+  assert.equal(command.sessionId, 'child-session');
+  assert.match(command.params.expression, /__attachedSessionDefaultScript/);
 });
 
 test('ExecutionContext.evaluate converts CDP exception details into thrown objects', async () => {


### PR DESCRIPTION
## Summary
- add session-level script defaults and apply them to Session/ExecutionContext evaluate paths
- propagate setup initScript/timeout into session defaults and auto-attached sessions
- cover default script behavior in mock/e2e tests

## Tests
- npm run test